### PR TITLE
fix: resolve Safari iOS viewport overflow and click events on non-interactive divs

### DIFF
--- a/frontend/src/app/app.css
+++ b/frontend/src/app/app.css
@@ -1,3 +1,11 @@
+/* Safari iOS uses the large viewport (URL bar hidden) for 100vh, which causes
+   the layout to exceed the visible area when the URL bar is shown. dvh tracks
+   the actual visible viewport dynamically, with vh as a fallback. */
+.app-height {
+  height: 100vh;
+  height: 100dvh;
+}
+
 .scrollbar-auto-hide {
   overflow-y: auto;
   scrollbar-gutter: stable;

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,4 +1,4 @@
-<div class="flex flex-col h-screen">
+<div class="flex flex-col app-height">
   <div class="navbar bg-base-200 shadow-sm shrink-0">
     <div class="navbar-start">
       <a routerLink="/" class="btn btn-ghost text-xl px-1 sm:px-4">

--- a/frontend/src/pages/bill/bill.css
+++ b/frontend/src/pages/bill/bill.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  overflow: hidden;
 }
 
 .footer-shadow {
@@ -40,7 +41,7 @@
 }
 
 .detail-panel-open {
-  max-height: 50vh;
+  max-height: 50dvh;
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/bill/bill.html
+++ b/frontend/src/pages/bill/bill.html
@@ -1,5 +1,5 @@
 <!-- Bill content -->
-<div class="flex-1 container mx-auto p-4">
+<div class="flex-1 overflow-y-auto container mx-auto p-4">
   @if (loading()) {
   <div class="flex justify-center py-12">
     <span class="loading loading-spinner loading-lg"></span>
@@ -21,7 +21,7 @@
     <div class="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-3">
       @for (product of category.products; track product.id) {
       @let qty = getQuantity(product.id);
-      <div #productCard class="collapse bg-base-200 product-card shadow-sm rounded-box scroll-mt-12"
+      <div #productCard class="collapse bg-base-200 product-card shadow-sm rounded-box scroll-mt-12 cursor-pointer"
         [id]="'product-' + product.id"
         [class.card-selected]="qty > 0"
         (click)="addProduct(product, category)">
@@ -69,7 +69,7 @@
 </div>
 
 <!-- Persistent footer -->
-<footer class="sticky bottom-0 bg-base-200 footer-shadow">
+<footer class="bg-base-200 footer-shadow">
   <!-- Totals bar (always visible) -->
   <div class="container mx-auto flex items-center p-3 sm:p-4"
     [class.cursor-pointer]="totalItems() > 0"

--- a/frontend/src/pages/settings/components/theme-selector/theme-selector.html
+++ b/frontend/src/pages/settings/components/theme-selector/theme-selector.html
@@ -32,11 +32,11 @@
     <div class="rounded-box grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-7">
       @for (theme of themes; track theme) {
         <div
-          class="border-base-content/20 hover:border-base-content/40 overflow-hidden rounded border outline-2 outline-offset-1 outline-transparent"
+          class="border-base-content/20 hover:border-base-content/40 overflow-hidden rounded border outline-2 outline-offset-1 outline-transparent cursor-pointer"
           [class.outline-base-content!]="theme === themeService.currentTheme()"
           (click)="selectTheme(theme)"
         >
-          <div class="bg-base-100 text-base-content w-full cursor-pointer" [attr.data-theme]="theme">
+          <div class="bg-base-100 text-base-content w-full" [attr.data-theme]="theme">
             <div class="grid grid-cols-5 grid-rows-3">
               <div class="bg-base-200 col-start-1 row-span-2 row-start-1"></div>
               <div class="bg-base-300 col-start-1 row-start-3"></div>


### PR DESCRIPTION
## Summary
- Replace `h-screen` (`100vh`) with a `100dvh` fallback class to fix Safari iOS URL-bar viewport overflow
- Make bill content area independently scrollable (`overflow-y-auto`) and remove `sticky bottom-0` from footer so the layout stays within the dynamic viewport
- Add `cursor-pointer` to all clickable `<div>` elements (product cards, theme selector cards) so iOS Safari dispatches click events
- Replace `50vh` with `50dvh` on the expandable detail panel
- Add `overflow: hidden` to `.bill-content` to prevent double scrollbars

Closes #1 
