### PR TITLE
fix: Safe area insets for curved screens on PWA

### DIFF
--- a/.claude/commands/test-local-mobile.md
+++ b/.claude/commands/test-local-mobile.md
@@ -1,0 +1,109 @@
+Mobile testing session using cloudflared. Applies temporary local config, verifies all services, exposes a public HTTPS tunnel URL for testing on physical devices, then reverts all changes cleanly when done.
+
+---
+
+## Phase 1 — Apply temporary changes
+
+Make the following 3 changes to enable mobile testing:
+
+1. Create `frontend/proxy.conf.json` with this exact content:
+   ```json
+   {
+     "/api": {
+       "target": "http://localhost:3000",
+       "secure": false,
+       "changeOrigin": true
+     }
+   }
+   ```
+
+2. In `frontend/angular.json`, add an `options` block to the `serve` target (between `"builder"` and `"configurations"`):
+   ```json
+   "options": {
+     "allowedHosts": true,
+     "proxyConfig": "proxy.conf.json"
+   },
+   ```
+
+3. In `frontend/src/environments/environment.ts`, change `apiUrl` to:
+   ```ts
+   apiUrl: '/api',
+   ```
+
+After applying the 3 changes, report them as a checklist and continue.
+
+---
+
+## Phase 2 — Verify services
+
+Run all 3 checks in parallel and report each result clearly:
+
+```bash
+docker ps --format "table {{.Names}}\t{{.Status}}"
+```
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/menu
+```
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:4200
+```
+
+Expected results:
+- Docker: containers listed (not empty output)
+- Backend: HTTP `200`
+- Frontend: HTTP `200`
+
+If any service is down, tell the user exactly what to start:
+- Docker not running → start Docker Desktop
+- Backend down → `cd backend && npm run dev`
+- Frontend down → `cd frontend && ng serve --port 4200`
+
+Wait for the user to confirm all services are running before continuing.
+
+---
+
+## Phase 3 — Start tunnel and share URL
+
+Run cloudflared in the background and capture its output:
+
+```bash
+cloudflared tunnel --url http://localhost:4200 > /tmp/cf-mobile-test.log 2>&1 &
+echo $! > /tmp/cf-mobile-test.pid
+sleep 8
+cat /tmp/cf-mobile-test.log
+```
+
+Extract the public URL from the log (format: `https://[words].trycloudflare.com`) and display it prominently to the user.
+
+Tell the user:
+- Open that URL on any mobile device on any network
+- The tunnel is active until they confirm they are done
+
+Wait for the user to say they are done testing.
+
+---
+
+## Phase 4 — Revert all changes
+
+Once the user confirms they are done, revert everything in this order:
+
+1. Stop cloudflared:
+   ```bash
+   kill $(cat /tmp/cf-mobile-test.pid) 2>/dev/null; rm -f /tmp/cf-mobile-test.pid /tmp/cf-mobile-test.log
+   ```
+
+2. Revert `frontend/src/environments/environment.ts` — set `apiUrl` back to:
+   ```ts
+   apiUrl: 'http://localhost:3000/api',
+   ```
+
+3. Revert `frontend/angular.json` — remove the entire `options` block added in Phase 1 from the `serve` target.
+
+4. Delete `frontend/proxy.conf.json`.
+
+5. Run `git diff` on the 2 tracked files to confirm zero changes remain:
+   ```bash
+   git diff frontend/angular.json frontend/src/environments/environment.ts
+   ```
+
+6. Confirm to the user: all temporary changes reverted, no traces left, repository is clean and ready to commit or continue development.

--- a/frontend/src/app/app.css
+++ b/frontend/src/app/app.css
@@ -1,3 +1,7 @@
+.safe-area-top {
+  padding-top: env(safe-area-inset-top);
+}
+
 /* Safari iOS uses the large viewport (URL bar hidden) for 100vh, which causes
    the layout to exceed the visible area when the URL bar is shown. dvh tracks
    the actual visible viewport dynamically, with vh as a fallback. */

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,5 +1,5 @@
 <div class="flex flex-col app-height">
-  <div class="navbar bg-base-200 shadow-sm shrink-0">
+  <div class="navbar bg-base-200 shadow-sm shrink-0 safe-area-top">
     <div class="navbar-start">
       <a routerLink="/" class="btn btn-ghost text-xl px-1 sm:px-4">
         <img src="assets/dolphin64.png" alt="MEPPOS" class="size-8" />

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>MEPPOS</title>
   <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#ffffff">
   <meta name="description" content="Sistema de punto de venta para marisquería">
   <meta name="mobile-web-app-capable" content="yes">

--- a/frontend/src/pages/bill/bill.css
+++ b/frontend/src/pages/bill/bill.css
@@ -7,6 +7,14 @@
 
 .footer-shadow {
   box-shadow: 0 -1px 3px 0 rgb(0 0 0 / 0.1), 0 -1px 2px -1px rgb(0 0 0 / 0.1);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}
+
+.bill-content {
+  padding-left: max(1rem, env(safe-area-inset-left));
+  padding-right: max(1rem, env(safe-area-inset-right));
 }
 
 .collapse-arrow-toggle {

--- a/frontend/src/pages/bill/bill.html
+++ b/frontend/src/pages/bill/bill.html
@@ -1,5 +1,5 @@
 <!-- Bill content -->
-<div class="flex-1 overflow-y-auto container mx-auto p-4">
+<div class="flex-1 overflow-y-auto container mx-auto p-4 bill-content">
   @if (loading()) {
   <div class="flex justify-center py-12">
     <span class="loading loading-spinner loading-lg"></span>


### PR DESCRIPTION
## Summary

- Added `viewport-fit=cover` to the viewport meta tag to allow content to extend into safe area regions
- Added `env(safe-area-inset-top)` padding to the navbar via `.safe-area-top` utility class
- Added `env(safe-area-inset-bottom/left/right)` padding to the bill footer (`.footer-shadow`)
- Added `env(safe-area-inset-left/right)` padding to the bill content area (`.bill-content`) using `max()` to preserve the base padding on non-curved devices

## Test plan

- [ ] Open the app as an installed PWA on iPhone 16 Pro Max (iOS 26)
- [ ] Navigate to the bill page and add products
- [ ] Verify quantity badges on product cards are fully visible at screen edges
- [ ] Verify the footer total and item count are not clipped by the home indicator area
- [ ] Verify layout is unchanged on non-curved devices and in browser mode

Closes #7