### PR TITLE
feat: add animated splash screen on app startup

### DIFF
--- a/.claude/commands/Fase 1 - App Marisquería (Calculadora de Cuentas).md
+++ b/.claude/commands/Fase 1 - App Marisquería (Calculadora de Cuentas).md
@@ -402,6 +402,7 @@ billItems: Map<number, BillItem>;  // keyed by productId
 - [x] Theme selector with DaisyUI themes (localStorage persistence)
 - [x] Shared components: toast, confirm-dialog, icon
 - [x] PWA compatibility (manifest.webmanifest, service worker via @angular/service-worker, dynamic theme-color meta tag sync)
+- [x] Animated splash screen (themed, content-aware dismissal with minimum display time)
 
 ### Testing (opcional para Fase 1, pero recomendado)
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The system uses 2 tables:
 - ✅ Shared icon component
 - ✅ Bill calculator interface (product grid by category — categories without products are hidden; DaisyUI collapse cards with integer-only quantity controls; expandable footer with scrollable item detail, sticky header/trash button, and real-time total; clicking a detail row scrolls to and highlights the product card)
 - ✅ PWA compatibility (installable, service worker with asset caching, web app manifest, dynamic theme-color sync)
+- ✅ Animated splash screen with branded entry animation and content-aware dismissal
 
 ### Future Phases
 
@@ -282,7 +283,7 @@ frontend/src/
 ├── core/
 │   ├── guards/       # Route guards (unsaved changes)
 │   ├── models/       # TypeScript interfaces
-│   └── services/     # Angular services (HTTP, theme, toast, confirm dialog, category, product)
+│   └── services/     # Angular services (HTTP, theme, toast, confirm dialog, category, product, splash)
 ├── environments/     # Environment configs (dev/prod)
 ├── pages/            # Page components (menu, bill, settings)
 │   └── settings/components/  # Settings sub-components (theme-selector, category-manager, product-manager)

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, inject, viewChild } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { ThemeService } from '../core/services/theme.service';
+import { SplashService } from '../core/services/splash.service';
 import { ToastComponent } from '../shared/components/toast/toast';
 import { ConfirmDialogComponent } from '../shared/components/confirm-dialog/confirm-dialog';
 
@@ -17,6 +18,7 @@ export class App {
 
   constructor() {
     inject(ThemeService).init();
+    inject(SplashService);
   }
 
   onScroll(): void {

--- a/frontend/src/core/services/splash.service.ts
+++ b/frontend/src/core/services/splash.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+
+const MINIMUM_DISPLAY_MS = 1200;
+const MAXIMUM_DISPLAY_MS = 5000;
+
+@Injectable({ providedIn: 'root' })
+export class SplashService {
+  private dismissed = false;
+  private contentReadyResolve!: () => void;
+
+  private readonly contentReady$ = new Promise<void>((resolve) => {
+    this.contentReadyResolve = resolve;
+  });
+
+  private readonly minimumDelay$ = new Promise<void>((resolve) => {
+    setTimeout(resolve, MINIMUM_DISPLAY_MS);
+  });
+
+  private readonly maxTimeout$ = new Promise<void>((resolve) => {
+    setTimeout(resolve, MAXIMUM_DISPLAY_MS);
+  });
+
+  constructor() {
+    this.waitAndDismiss();
+  }
+
+  contentReady(): void {
+    this.contentReadyResolve();
+  }
+
+  private async waitAndDismiss(): Promise<void> {
+    await Promise.race([
+      Promise.all([this.minimumDelay$, this.contentReady$]),
+      this.maxTimeout$,
+    ]);
+    this.dismiss();
+  }
+
+  private dismiss(): void {
+    if (this.dismissed) return;
+    this.dismissed = true;
+
+    const splash = document.getElementById('splash-screen');
+    if (!splash) return;
+
+    splash.classList.add('splash-exit');
+
+    const cleanup = () => splash.remove();
+    splash.addEventListener('transitionend', cleanup, { once: true });
+    setTimeout(cleanup, 500);
+  }
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -14,8 +14,81 @@
   <link rel="icon" type="image/png" href="assets/dolphin64.png">
   <link rel="apple-touch-icon" href="assets/dolphin256.png">
   <link rel="manifest" href="manifest.webmanifest">
+  <script>
+    (function() {
+      var t = localStorage.getItem('meppos-theme') || 'light';
+      document.documentElement.setAttribute('data-theme', t);
+      var darkThemes = ['dark','synthwave','halloween','forest','black','luxury','dracula',
+                        'business','night','coffee','dim','abyss','sunset'];
+      var meta = document.querySelector('meta[name="theme-color"]');
+      if (meta && darkThemes.indexOf(t) !== -1) {
+        meta.setAttribute('content', '#1f2937');
+      }
+    })();
+  </script>
+  <style>
+    #splash-screen {
+      position: fixed;
+      inset: 0;
+      z-index: 9999;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background-color: var(--color-base-100, #ffffff);
+      color: var(--color-base-content, #1f2937);
+      transition: opacity 0.4s ease-out;
+    }
+    #splash-screen.splash-exit {
+      opacity: 0;
+      pointer-events: none;
+    }
+    .splash-content {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+    }
+    .splash-logo {
+      width: 8rem;
+      height: 8rem;
+      object-fit: contain;
+      animation: splash-logo-entry 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+    }
+    .splash-title {
+      font-family: system-ui, -apple-system, sans-serif;
+      font-size: 1.75rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      opacity: 0;
+      animation: splash-text-entry 0.4s ease-out 0.35s forwards;
+    }
+    @keyframes splash-logo-entry {
+      from { opacity: 0; transform: scale(0.6) translateY(0.5rem); }
+      to   { opacity: 1; transform: scale(1) translateY(0); }
+    }
+    @keyframes splash-text-entry {
+      from { opacity: 0; transform: translateY(0.5rem); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .splash-logo, .splash-title {
+        animation: none;
+        opacity: 1;
+        transform: none;
+      }
+      #splash-screen {
+        transition-duration: 0.1s;
+      }
+    }
+  </style>
 </head>
 <body>
+  <div id="splash-screen">
+    <div class="splash-content">
+      <img src="assets/dolphin256.png" alt="" class="splash-logo" />
+      <span class="splash-title">MEPPOS</span>
+    </div>
+  </div>
   <app-root></app-root>
 </body>
 </html>

--- a/frontend/src/pages/bill/bill.ts
+++ b/frontend/src/pages/bill/bill.ts
@@ -1,5 +1,6 @@
 import { Component, computed, ElementRef, inject, OnInit, signal, viewChildren } from '@angular/core';
 import { MenuService } from '../../core/services/menu.service';
+import { SplashService } from '../../core/services/splash.service';
 import { ConfirmDialogService } from '../../core/services/confirm-dialog.service';
 import type { HasUnsavedChanges } from '../../core/guards/unsaved-changes.guard';
 import type { MenuCategory, MenuProduct } from '../../core/models';
@@ -20,6 +21,7 @@ interface BillItem {
 })
 export class BillPage implements OnInit, HasUnsavedChanges {
   private readonly menuService = inject(MenuService);
+  private readonly splashService = inject(SplashService);
   private readonly confirmDialogService = inject(ConfirmDialogService);
 
   private readonly productCards = viewChildren<ElementRef>('productCard');
@@ -53,10 +55,12 @@ export class BillPage implements OnInit, HasUnsavedChanges {
       next: (data) => {
         this.categories.set(data);
         this.loading.set(false);
+        this.splashService.contentReady();
       },
       error: () => {
         this.error.set('Error al cargar el menú');
         this.loading.set(false);
+        this.splashService.contentReady();
       },
     });
   }

--- a/frontend/src/pages/menu/menu.ts
+++ b/frontend/src/pages/menu/menu.ts
@@ -1,5 +1,6 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { MenuService } from '../../core/services/menu.service';
+import { SplashService } from '../../core/services/splash.service';
 import type { MenuCategory } from '../../core/models';
 
 @Component({
@@ -9,6 +10,7 @@ import type { MenuCategory } from '../../core/models';
 })
 export class MenuPage implements OnInit {
   private readonly menuService = inject(MenuService);
+  private readonly splashService = inject(SplashService);
 
   categories = signal<MenuCategory[]>([]);
   loading = signal(true);
@@ -19,10 +21,12 @@ export class MenuPage implements OnInit {
       next: (data) => {
         this.categories.set(data);
         this.loading.set(false);
+        this.splashService.contentReady();
       },
       error: () => {
         this.error.set('Error al cargar el menú');
         this.loading.set(false);
+        this.splashService.contentReady();
       },
     });
   }

--- a/frontend/src/pages/settings/settings.ts
+++ b/frontend/src/pages/settings/settings.ts
@@ -1,8 +1,9 @@
-import { Component, inject, signal, viewChild } from '@angular/core';
+import { Component, inject, OnInit, signal, viewChild } from '@angular/core';
 import { ThemeSelectorComponent } from './components/theme-selector/theme-selector';
 import { CategoryManagerComponent } from './components/category-manager/category-manager';
 import { ProductManagerComponent } from './components/product-manager/product-manager';
 import { ConfirmDialogService } from '../../core/services/confirm-dialog.service';
+import { SplashService } from '../../core/services/splash.service';
 import { HasUnsavedChanges } from '../../core/guards/unsaved-changes.guard';
 
 @Component({
@@ -11,14 +12,19 @@ import { HasUnsavedChanges } from '../../core/guards/unsaved-changes.guard';
   templateUrl: './settings.html',
   styleUrl: './settings.css',
 })
-export class SettingsPage implements HasUnsavedChanges {
+export class SettingsPage implements HasUnsavedChanges, OnInit {
   private readonly confirmDialogService = inject(ConfirmDialogService);
+  private readonly splashService = inject(SplashService);
 
   categoryManager = viewChild(CategoryManagerComponent);
   productManager = viewChild(ProductManagerComponent);
 
   activeTab = signal<'categories' | 'products'>('categories');
   hasTabSwitched = signal(false);
+
+  ngOnInit(): void {
+    this.splashService.contentReady();
+  }
 
   hasUnsavedChanges(): boolean {
     const categoryMgr = this.categoryManager();


### PR DESCRIPTION
## Summary

- Added branded splash screen with dolphin logo and entry animations (bounce-in + fade-up) rendered in `index.html` before Angular bootstraps
- Created `SplashService` with coordinated timing: minimum display (1.2s), content-ready signal from page components, and 5s safety timeout
- Integrated early theme sync via inline script to prevent white flash on dark themes
- Added `prefers-reduced-motion` support for accessibility

## Technical Details

- Splash overlay is a sibling of `<app-root>` (not inside it) so Angular bootstraps underneath while the splash persists
- Each page component signals `contentReady()` after data loads (or errors), ensuring splash stays until meaningful content is available
- `SplashService` uses `Promise.race([Promise.all([minDelay, contentReady]), maxTimeout])` for coordinated dismissal
- No new dependencies — pure CSS animations + vanilla JS theme sync

## Test plan

- [x] Fast load: splash shows full animation (~1.2s) then fades out smoothly
- [x] Slow load (DevTools → Slow 3G): splash stays until menu data arrives
- [x] Backend stopped: splash holds up to 5s, then page error state shows
- [x] Dark theme → refresh: splash uses dark background (no white flash)
- [x] Direct navigation to `/bill` and `/settings` works correctly
- [x] `prefers-reduced-motion` toggle in DevTools disables animations
- [x] iOS Safari and Android Chrome compatibility

Closes #10