### PR TITLE
Fixed decimal paste bypass in bill quantity inputs

### DIFF
--- a/frontend/src/pages/bill/bill.html
+++ b/frontend/src/pages/bill/bill.html
@@ -52,6 +52,7 @@
               min="1"
               step="1"
               (keydown)="preventNonIntegerInput($event)"
+              (paste)="preventDecimalPaste($event)"
               (change)="onQuantityChange(product.id, $event)"
             />
             <button class="join-item btn btn-soft btn-sm btn-success border border-current" (click)="incrementProduct(product.id)">

--- a/frontend/src/pages/bill/bill.ts
+++ b/frontend/src/pages/bill/bill.ts
@@ -116,6 +116,13 @@ export class BillPage implements OnInit, HasUnsavedChanges {
     }
   }
 
+  preventDecimalPaste(event: ClipboardEvent): void {
+    const text = event.clipboardData?.getData('text') ?? '';
+    if (!/^\d+$/.test(text)) {
+      event.preventDefault();
+    }
+  }
+
   hasUnsavedChanges(): boolean {
     return this.billItems().size > 0;
   }


### PR DESCRIPTION
## Summary

- Added `preventDecimalPaste()` handler to the quantity input's `(paste)` event in the bill page
- The handler reads the clipboard text and calls `event.preventDefault()` if it contains any non-digit character (decimals, negatives, letters, etc.)
- Complements the existing `preventNonIntegerInput()` which already blocked typed non-integer characters

## Test plan

- [x] Type a decimal (e.g. `1.5`) into a quantity field — rejected
- [x] Paste a decimal (e.g. `1.5`) into a quantity field — rejected
- [x] Paste a negative number (e.g. `-3`) — rejected
- [x] Paste a valid integer (e.g. `4`) — accepted
- [x] Increment/decrement buttons still work correctly

Closes #15