### PR TITLE
Fixed input label resize on mobile caused by iOS Safari auto-zoom

### DIFF
--- a/frontend/src/app/app.css
+++ b/frontend/src/app/app.css
@@ -38,3 +38,11 @@
 .scrollbar-auto-hide.scrolling::-webkit-scrollbar-thumb {
   background: oklch(0.5 0 0 / 0.4);
 }
+
+/* iOS Safari auto-zooms when a focused input has font-size < 16px, causing labels
+   to visually resize. A 16px floor prevents the zoom without overriding larger sizes. */
+input,
+select,
+textarea {
+  font-size: max(16px, 1em);
+}


### PR DESCRIPTION
Closes #14

## Summary
- Added global `font-size: max(16px, 1em)` rule for `input`, `select`, and `textarea` elements in `app.css`
- iOS Safari auto-zooms the viewport when a focused input has `font-size < 16px` (DaisyUI default is ~14px), which causes labels to visually resize
- The `max()` floor prevents the zoom without overriding larger sizes defined by the theme

## Test plan
- [x] Open the app on a mobile device or iOS Safari (or emulator)
- [x] Tap any input field and verify the label does not resize on focus
- [x] Verify form fields in login, settings (categories, products, users), and confirm dialog are unaffected visually