### PR TITLE
Fixed input label resize on mobile by moving iOS fix to global styles

### DIFF
--- a/frontend/src/app/app.css
+++ b/frontend/src/app/app.css
@@ -39,10 +39,3 @@
   background: oklch(0.5 0 0 / 0.4);
 }
 
-/* iOS Safari auto-zooms when a focused input has font-size < 16px, causing labels
-   to visually resize. A 16px floor prevents the zoom without overriding larger sizes. */
-input,
-select,
-textarea {
-  font-size: max(16px, 1em);
-}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -4,3 +4,20 @@
 @plugin "daisyui" {
   themes: all;
 }
+
+/* iOS Safari auto-zooms when a focused input has font-size < 16px. DaisyUI v5 fixes
+   this by bumping --font-size to 1rem on .input:focus-within, but that causes child
+   .label spans to resize via font-size:inherit. We apply the 16px floor directly on
+   the inner elements and neutralize the wrapper change to keep labels stable. */
+@supports (-webkit-touch-callout: none) {
+  input,
+  select,
+  textarea {
+    font-size: 16px;
+  }
+
+  .input:focus,
+  .input:focus-within {
+    --font-size: 0.875rem;
+  }
+}


### PR DESCRIPTION
Closes #14

## Summary
- Moved iOS Safari fix from `app.css` (scoped component styles) to `styles.css` (global) — the previous fix never reached inputs in child components due to Angular's ViewEncapsulation
- Added `font-size: 16px` on `input`, `select`, `textarea` inside `@supports (-webkit-touch-callout: none)` to prevent iOS auto-zoom
- Added `--font-size: 0.875rem` override on `.input:focus-within` to neutralize DaisyUI v5's internal font-size bump on the wrapper, which was causing `.label` spans to resize via `font-size: inherit`

## Root cause
DaisyUI v5 intentionally sets `--font-size: 1rem` on `.input:focus-within` on touch iOS to prevent auto-zoom. However, child `<span class="label">` elements use `font-size: inherit`, so they visually resize on focus. The previous fix targeted scoped component styles and never applied globally.

## Test plan
- [ ] Open the app on iOS Safari or Brave for iOS
- [ ] Tap any input field (login, settings — categories, products, users)
- [ ] Verify the label does not resize on focus