### PR TITLE
Fix deploy-frontend: remove working-directory conflict with Vercel root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,4 +149,3 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           vercel-args: '--prod'
-          working-directory: ./frontend


### PR DESCRIPTION
## Summary

- Remove `working-directory: ./frontend` from deploy-frontend job — Vercel project has Root Directory set to `frontend/` in dashboard, causing a path conflict (`frontend/frontend/`)
- Also requires `DATABASE_URL` GitHub Secret updated to direct connection URL (port 5432) instead of pooler (port 6543) for Prisma migrations

## Context

First CD pipeline run (PR #31 merge) had two failures:
1. **Deploy Backend** hung on `prisma migrate deploy` — pooler URL doesn't support DDL operations
2. **Deploy Frontend** errored with "vercel.json should be inside of the provided root directory" — double-nesting of `frontend/`

Closes #30