### PR TITLE
Fix #20: PWA auto-update with forced reload prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,31 @@ Frontend will be running at `http://localhost:4200`
 ### Backend (`/backend`)
 
 ```bash
-npm run dev              # Development with hot-reload
-npm run build            # Compile to JavaScript
-npm start                # Run compiled version
-npm run prisma:migrate   # Create/apply migrations
-npm run prisma:studio    # Open Prisma Studio (DB GUI)
-npm run prisma:seed      # Seed database with sample data
-npm run db:reset         # Reset database (deletes everything)
+npm run dev                  # Development with hot-reload
+npm run build                # Compile to JavaScript
+npm start                    # Run compiled version
+npm run prisma:migrate       # Create/apply migrations
+npm run prisma:studio        # Open Prisma Studio (DB GUI)
+npm run prisma:seed          # Seed database with sample data
+npm run db:reset             # Reset database (deletes everything)
+npm test                     # Run unit tests
+npm run test:watch           # Run unit tests in watch mode
+npm run test:coverage        # Run unit tests with coverage report
+npm run test:db:up           # Start test PostgreSQL container
+npm run test:integration     # Run integration tests (requires test DB)
+npm run test:db:down         # Stop test PostgreSQL container
 ```
 
 ### Frontend (`/frontend`)
 
 ```bash
-npm start            # Development server
-npm run build        # Production build
-npm test             # Run tests
+npm start                # Development server
+npm run build            # Production build
+npm test                 # Run unit tests (Vitest)
+npm run e2e              # Run E2E tests headless (Playwright)
+npm run e2e:ui           # Run E2E tests with Playwright UI
+npm run e2e:headed       # Run E2E tests in headed browser
+npm run e2e:report       # Show last E2E test report
 ```
 
 ---
@@ -172,6 +182,7 @@ ADMIN_DEFAULT_PASSWORD=admin123
 - Angular CDK ^21.1.3
 - Angular Service Worker ^21.1.3
 - Vitest ^4.0.8
+- Playwright (E2E testing)
 - RxJS ~7.8.0
 
 ### Backend
@@ -232,6 +243,12 @@ The system uses 3 tables:
 - ✅ Conditional navbar (shown only when authenticated)
 - ✅ Public menu route for digital/QR access
 - ✅ Logout/user info in settings
+- ✅ Backend unit tests (JWT utilities, display-order helpers, price resolution)
+- ✅ Backend integration tests (categories, products, auth, users, public menu)
+- ✅ Frontend E2E tests with Playwright (auth flows, bill calculator)
+- ✅ GitHub Actions CI pipeline (backend + frontend jobs on every push)
+- ✅ CD pipeline (auto-deploy to Koyeb + Vercel on push to master after CI passes)
+- ✅ PWA auto-update: SwUpdate prompt with forced reload on new version
 - ⬜ Locations management (tables/bar with visual identifiers)
 - ⬜ Persistent orders with multiple rounds
 - ⬜ Custom extras and frequent extras list
@@ -326,7 +343,7 @@ frontend/src/
 │   ├── guards/       # Route guards (auth, unsaved changes)
 │   ├── interceptors/ # HTTP interceptors (auth token + 401 refresh)
 │   ├── models/       # TypeScript interfaces
-│   └── services/     # Angular services (auth, user, category, product, menu, theme, toast, confirm dialog, splash)
+│   └── services/     # Angular services (auth, user, category, product, menu, theme, toast, confirm dialog, splash, pwa-update)
 ├── environments/     # Environment configs (dev/prod)
 ├── pages/            # Page components (login, menu, bill, settings)
 │   └── settings/components/  # Settings sub-components (theme-selector, category-manager, product-manager, user-manager)

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -10,7 +10,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -3,6 +3,7 @@ import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/rou
 import { ThemeService } from '../core/services/theme.service';
 import { SplashService } from '../core/services/splash.service';
 import { AuthService } from '../core/services/auth.service';
+import { PwaUpdateService } from '../core/services/pwa-update.service';
 import { ToastComponent } from '../shared/components/toast';
 import { ConfirmDialogComponent } from '../shared/components/confirm-dialog';
 
@@ -21,6 +22,7 @@ export class App {
   constructor() {
     inject(ThemeService).init();
     inject(SplashService);
+    inject(PwaUpdateService).init();
     this.authService.initialize().subscribe();
   }
 

--- a/frontend/src/core/services/confirm-dialog.service.ts
+++ b/frontend/src/core/services/confirm-dialog.service.ts
@@ -6,6 +6,7 @@ export interface ConfirmDialogOptions {
   confirmText?: string;
   cancelText?: string;
   requireInput?: string;
+  cancelable?: boolean;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -17,6 +18,7 @@ export class ConfirmDialogService {
   readonly cancelText = signal('Cancelar');
   readonly requireInput = signal('');
   readonly inputValue = signal('');
+  readonly cancelable = signal(true);
 
   private resolver: ((value: boolean) => void) | null = null;
 
@@ -27,6 +29,7 @@ export class ConfirmDialogService {
     this.cancelText.set(options.cancelText ?? 'Cancelar');
     this.requireInput.set(options.requireInput ?? '');
     this.inputValue.set('');
+    this.cancelable.set(options.cancelable ?? true);
     this.visible.set(true);
 
     return new Promise<boolean>((resolve) => {

--- a/frontend/src/core/services/pwa-update.service.ts
+++ b/frontend/src/core/services/pwa-update.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, inject } from '@angular/core';
+import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
+import { filter } from 'rxjs/operators';
+import { ConfirmDialogService } from './confirm-dialog.service';
+
+@Injectable({ providedIn: 'root' })
+export class PwaUpdateService {
+  private swUpdate = inject(SwUpdate);
+  private confirmDialog = inject(ConfirmDialogService);
+
+  init(): void {
+    if (!this.swUpdate.isEnabled) return;
+
+    this.swUpdate.versionUpdates
+      .pipe(filter((e): e is VersionReadyEvent => e.type === 'VERSION_READY'))
+      .subscribe(() => this.promptUpdate());
+
+    setInterval(() => this.swUpdate.checkForUpdate(), 6 * 60 * 60 * 1000);
+  }
+
+  private promptUpdate(): void {
+    this.swUpdate.activateUpdate().then(() => {
+      this.confirmDialog
+        .confirm({
+          title: 'Nueva versión disponible',
+          message: 'La aplicación ha sido actualizada. Es necesario recargar para continuar.',
+          confirmText: 'Actualizar ahora',
+          cancelable: false,
+        })
+        .then(() => window.location.reload());
+    });
+  }
+}

--- a/frontend/src/shared/components/confirm-dialog/confirm-dialog.html
+++ b/frontend/src/shared/components/confirm-dialog/confirm-dialog.html
@@ -15,10 +15,12 @@
     }
 
     <div class="modal-action">
-      <button class="btn btn-soft btn-error" (click)="dialogService.cancel()"
-        [attr.aria-label]="dialogService.cancelText()">
-        <app-icon name="x-circle" />
-      </button>
+      @if (dialogService.cancelable()) {
+        <button class="btn btn-soft btn-error" (click)="dialogService.cancel()"
+          [attr.aria-label]="dialogService.cancelText()">
+          <app-icon name="x-circle" />
+        </button>
+      }
       <button class="btn btn-soft btn-success"
         [disabled]="dialogService.requireInput() && dialogService.inputValue() !== dialogService.requireInput()"
         (click)="dialogService.accept()"
@@ -27,7 +29,9 @@
       </button>
     </div>
   </div>
-  <form method="dialog" class="modal-backdrop">
-    <button (click)="dialogService.cancel()">close</button>
-  </form>
+  @if (dialogService.cancelable()) {
+    <form method="dialog" class="modal-backdrop">
+      <button (click)="dialogService.cancel()">close</button>
+    </form>
+  }
 </dialog>


### PR DESCRIPTION
## Summary
- Add `PwaUpdateService` that subscribes to `SwUpdate.versionUpdates` and triggers a forced update prompt when a new version is ready
- Add `cancelable` option to `ConfirmDialogService` (default `true`, backwards-compatible) to support non-dismissible dialogs
- Hide cancel button and backdrop close in `ConfirmDialogComponent` when `cancelable: false`
- Fix deprecated `moduleResolution: node` → `node10` in backend `tsconfig.json`
- Update README with test scripts, E2E scripts, Playwright in tech stack, completed Phase 2 items, and new service

## Test plan
- [x] Built production bundle and served with static server
- [x] Verified service worker registers correctly on first load
- [x] Confirmed new version triggers auto-reload (old SW behavior transitioning to new)
- [x] Confirmed new version shows forced confirm dialog with no cancel button
- [x] Confirmed clicking "Actualizar ahora" reloads and loads new version
- [x] Verified existing `cancelable` dialogs (16 usages) are unaffected

Closes #20