### PR TITLE
Fixed auth race condition causing navbar to appear on login page after session restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ backend/src/
 frontend/src/
 ├── app/              # Root component, routes, config
 ├── core/
-│   ├── guards/       # Route guards (auth, unsaved changes)
+│   ├── guards/       # Route guards (auth, no-auth, unsaved changes)
 │   ├── interceptors/ # HTTP interceptors (auth, server error handling with cold start retry)
 │   ├── models/       # TypeScript interfaces
 │   └── services/     # Angular services (auth, user, category, product, menu, theme, toast, confirm dialog, splash, pwa-update)

--- a/frontend/e2e/auth.e2e.ts
+++ b/frontend/e2e/auth.e2e.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import {
   setupApiMocks,
+  setupAuthenticatedMocks,
   setupLoginFailMocks,
   setupNetworkErrorMocks,
   setupColdStartMocks,
@@ -105,6 +106,16 @@ test.describe('Authentication', () => {
     await expect(page.locator('[data-testid="login-error"]')).toBeVisible({ timeout: 15_000 });
     await expect(page.locator('[data-testid="login-error"]')).toContainText('Usuario o contraseña incorrectos');
     await expect(page.locator('[data-testid="login-retry"]')).not.toBeVisible();
+  });
+
+  test('authenticated user accessing /login is redirected to /bill', async ({ page }) => {
+    await setupAuthenticatedMocks(page);
+    await page.route('**/api/menu', (route) =>
+      route.fulfill({ status: 200, json: { success: true, data: [] } }),
+    );
+    await page.goto('/login');
+
+    await expect(page).toHaveURL(/\/bill/);
   });
 
   test('shows cold start hint after extended loading', async ({ page }) => {

--- a/frontend/e2e/helpers/mocks.ts
+++ b/frontend/e2e/helpers/mocks.ts
@@ -59,6 +59,18 @@ export const mockMenu = [
   },
 ];
 
+export async function setupAuthenticatedMocks(page: Page): Promise<void> {
+  await page.route(`${API_BASE}/auth/refresh`, (route) =>
+    route.fulfill({
+      status: 200,
+      json: {
+        success: true,
+        data: { accessToken: 'test-access-token', user: mockUser },
+      },
+    }),
+  );
+}
+
 async function mockRefreshFail(page: Page): Promise<void> {
   await page.route(`${API_BASE}/auth/refresh`, (route) =>
     route.fulfill({ status: 401, json: { success: false, error: 'Unauthorized' } }),

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,11 +1,17 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners, isDevMode } from '@angular/core';
+import { ApplicationConfig, APP_INITIALIZER, provideBrowserGlobalErrorListeners, isDevMode } from '@angular/core';
 import { provideRouter, withViewTransitions } from '@angular/router';
 import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 import { provideServiceWorker } from '@angular/service-worker';
+import { firstValueFrom } from 'rxjs';
 
 import { routes } from './app.routes';
 import { authInterceptor } from '../core/interceptors/auth.interceptor';
 import { serverErrorInterceptor } from '../core/interceptors/server-error.interceptor';
+import { AuthService } from '../core/services/auth.service';
+
+function initializeAuth(authService: AuthService) {
+  return () => firstValueFrom(authService.initialize());
+}
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -16,5 +22,11 @@ export const appConfig: ApplicationConfig = {
       enabled: !isDevMode(),
       registrationStrategy: 'registerWhenStable:30000',
     }),
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initializeAuth,
+      deps: [AuthService],
+      multi: true,
+    },
   ],
 };

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { unsavedChangesGuard } from '../core/guards/unsaved-changes.guard';
 import { authGuard } from '../core/guards/auth.guard';
+import { noAuthGuard } from '../core/guards/no-auth.guard';
 
 export const routes: Routes = [
   {
@@ -11,6 +12,7 @@ export const routes: Routes = [
   {
     path: 'login',
     loadComponent: () => import('../pages/login/login').then(m => m.LoginPage),
+    canActivate: [noAuthGuard],
   },
   {
     path: 'menu',
@@ -30,6 +32,6 @@ export const routes: Routes = [
   },
   {
     path: '**',
-    redirectTo: 'menu',
+    redirectTo: 'login',
   },
 ];

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -23,7 +23,6 @@ export class App {
     inject(ThemeService).init();
     inject(SplashService);
     inject(PwaUpdateService).init();
-    this.authService.initialize().subscribe();
   }
 
   onScroll(): void {

--- a/frontend/src/core/guards/no-auth.guard.spec.ts
+++ b/frontend/src/core/guards/no-auth.guard.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { noAuthGuard } from './no-auth.guard';
+import { AuthService } from '../services/auth.service';
+
+describe('noAuthGuard', () => {
+  function setup(isAuthenticated: boolean) {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: { isAuthenticated: () => isAuthenticated } },
+      ],
+    });
+  }
+
+  function run() {
+    return TestBed.runInInjectionContext(() => noAuthGuard({} as any, {} as any));
+  }
+
+  describe('when not authenticated', () => {
+    beforeEach(() => setup(false));
+
+    it('returns true (allows access to login)', () => {
+      expect(run()).toBe(true);
+    });
+  });
+
+  describe('when authenticated', () => {
+    beforeEach(() => setup(true));
+
+    it('returns a UrlTree redirecting to /bill', () => {
+      const router = TestBed.inject(Router);
+      expect(run()).toEqual(router.createUrlTree(['/bill']));
+    });
+  });
+});

--- a/frontend/src/core/guards/no-auth.guard.ts
+++ b/frontend/src/core/guards/no-auth.guard.ts
@@ -1,0 +1,14 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+
+export const noAuthGuard: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (!authService.isAuthenticated()) {
+    return true;
+  }
+
+  return router.createUrlTree(['/bill']);
+};

--- a/frontend/src/pages/login/login.spec.ts
+++ b/frontend/src/pages/login/login.spec.ts
@@ -11,13 +11,12 @@ describe('LoginPage', () => {
   let fixture: ComponentFixture<LoginPage>;
   let component: LoginPage;
   let loginSubject: Subject<unknown>;
-  let authServiceMock: { isAuthenticated: () => boolean; login: ReturnType<typeof vi.fn> };
+  let authServiceMock: { login: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
     loginSubject = new Subject();
 
     authServiceMock = {
-      isAuthenticated: () => false,
       login: vi.fn().mockReturnValue(loginSubject.asObservable()),
     };
 

--- a/frontend/src/pages/login/login.ts
+++ b/frontend/src/pages/login/login.ts
@@ -5,7 +5,6 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { AuthService } from '../../core/services/auth.service';
 import { COLD_START_STATUS } from '../../core/interceptors/server-error.interceptor';
 
-// Delay before showing the cold start hint to the user (ms).
 // Aligns with the first retry window so the hint appears as the server is waking up.
 const COLD_START_HINT_DELAY_MS = 4000;
 
@@ -23,9 +22,6 @@ export class LoginPage {
   password = '';
 
   constructor() {
-    if (this.authService.isAuthenticated()) {
-      this.router.navigate(['/bill']);
-    }
     inject(DestroyRef).onDestroy(() => this.clearHint());
   }
 


### PR DESCRIPTION
## Summary

- Add `APP_INITIALIZER` to ensure `authService.initialize()` (refresh via cookies) completes before Angular activates any route, eliminating the race condition
- Add `noAuthGuard` to redirect authenticated users away from `/login` to `/bill`
- Apply `noAuthGuard` to `/login` route; change wildcard `**` redirect from `menu` → `login`
- Remove unreliable constructor-based `isAuthenticated()` redirect from `LoginPage` (now handled by guard)
- Add unit tests for `noAuthGuard` (2 cases: allow unauthenticated, redirect authenticated)
- Add E2E test: authenticated user accessing `/login` is redirected to `/bill`
- Remove dead `isAuthenticated` mock field from `login.spec.ts`
- Update README guards description

## Test plan

- [x] Unit tests pass (17 → 19): `no-auth.guard.spec.ts` covers both guard paths
- [x] E2E tests pass (9 → 10): new test directly covers the reported regression scenario
- [x] Verify: after PWA reload with valid session, app redirects to `/bill` instead of showing navbar on login
- [x] Verify: unauthenticated user accessing `/bill` or `/settings` is redirected to `/login`
- [x] Verify: after logout, `/login` shows correctly with no navbar

Closes #35