### PR TITLE
feat: custom_extras and locations — DB, API, and admin UI

### DIFF
--- a/.claude/docs/phases/Fase 2 - App Marisqueria (Registro de Cuentas).md
+++ b/.claude/docs/phases/Fase 2 - App Marisqueria (Registro de Cuentas).md
@@ -33,7 +33,7 @@ Extensión de la calculadora de Fase 1 hacia un sistema de cuentas persistentes.
 - ✅ Para llevar con consecutivo diario
 - ✅ Impresión de tickets de cocina y ticket final
 - ✅ Historial consultable con reimpresión marcada como copia
-- ✅ Identificadores visuales para posiciones de barra
+- ✅ Identificador numérico auto-asignado para órdenes de barra (consecutivo diario, reinicio a las 00:00)
 
 ---
 
@@ -102,7 +102,6 @@ Sin cambios respecto a Fase 1. Se extienden las capas existentes.
 │                                 │
 │  categories, products (Fase 1)  │
 │  locations                      │
-│  location_identifiers           │
 │  orders                         │
 │  order_rounds                   │
 │  order_items                    │
@@ -117,7 +116,7 @@ Sin cambios respecto a Fase 1. Se extienden las capas existentes.
 
 ### Tabla: `locations`
 
-Mesas y barras configurables. Una barra puede tener múltiples cuentas activas simultáneas a través de identificadores visuales.
+Mesas y barras configurables. Una barra puede tener múltiples cuentas activas simultáneas; cada orden de barra recibe un identificador numérico auto-asignado por el sistema (ver `orders.bar_position`).
 
 ```sql
 CREATE TABLE locations (
@@ -131,20 +130,6 @@ CREATE TABLE locations (
 );
 ```
 
-### Tabla: `location_identifiers`
-
-Identificadores visuales para posiciones dentro de la barra (ej. "estrella", "luna", "corazón"). Referencia física para colocar junto al cliente.
-
-```sql
-CREATE TABLE location_identifiers (
-  id         SERIAL PRIMARY KEY,
-  label      VARCHAR(100) NOT NULL,
-  icon       VARCHAR(100),           -- nombre de icono o emoji
-  active     BOOLEAN DEFAULT true,
-  created_at TIMESTAMP DEFAULT NOW()
-);
-```
-
 ### Tabla: `orders`
 
 Cuenta abierta por un mesero para una ubicación específica.
@@ -153,7 +138,7 @@ Cuenta abierta por un mesero para una ubicación específica.
 CREATE TABLE orders (
   id              SERIAL PRIMARY KEY,
   location_id     INTEGER REFERENCES locations(id),
-  identifier_id   INTEGER REFERENCES location_identifiers(id),  -- solo para barra
+  bar_position    INTEGER,            -- solo para barra (consecutivo diario auto-asignado)
   takeout_number  INTEGER,            -- solo para para llevar (consecutivo diario)
   order_type      VARCHAR(20) NOT NULL CHECK (order_type IN ('dine_in', 'bar', 'takeout')),
   status          VARCHAR(20) NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'charged', 'cancelled')),
@@ -163,6 +148,8 @@ CREATE TABLE orders (
   notes           TEXT
 );
 ```
+
+> `bar_position` y `takeout_number` siguen el mismo patrón: el backend calcula el siguiente valor al crear la orden como `MAX(campo) + 1` filtrando por `opened_at >= inicio_del_día_local`, de modo que ambos contadores reinician a las 00:00 sin requerir cron.
 
 ### Tabla: `order_rounds`
 
@@ -203,7 +190,7 @@ Lista de extras frecuentes reutilizables, administrable por cualquier mesero.
 CREATE TABLE custom_extras (
   id          SERIAL PRIMARY KEY,
   name        VARCHAR(255) NOT NULL UNIQUE,
-  default_price DECIMAL(10,2),
+  default_price DECIMAL(10,2) NOT NULL,
   active      BOOLEAN DEFAULT true,
   created_by  INTEGER REFERENCES users(id),
   created_at  TIMESTAMP DEFAULT NOW(),
@@ -235,8 +222,8 @@ CREATE TABLE order_discounts (
 
 1. Mesero selecciona tipo: mesa / barra / para llevar
 2. Si es mesa: selecciona mesa disponible
-3. Si es barra: selecciona identificador visual disponible
-4. Si es para llevar: sistema asigna número consecutivo del día
+3. Si es barra: sistema asigna automáticamente el siguiente número consecutivo del día (`bar_position`)
+4. Si es para llevar: sistema asigna número consecutivo del día (`takeout_number`)
 5. Se crea `order` con status `open` y `owner_user_id` del mesero activo
 
 ### Agregar ronda
@@ -250,7 +237,7 @@ CREATE TABLE order_discounts (
 
 Contenido:
 
-- Ubicación (nombre de mesa / identificador de barra / número para llevar)
+- Ubicación (nombre de mesa / barra con `bar_position` / número para llevar)
 - Mesero
 - Número de ronda
 - Lista de items con cantidad y nombre
@@ -313,9 +300,6 @@ Todas las respuestas siguen el mismo formato de Fase 1: `{ success: boolean, dat
 | POST | `/api/locations` | Crea una ubicación (admin) |
 | PUT | `/api/locations/:id` | Edita una ubicación (admin) |
 | DELETE | `/api/locations/:id` | Desactiva una ubicación (admin) |
-| GET | `/api/location-identifiers` | Lista identificadores de barra |
-| POST | `/api/location-identifiers` | Crea identificador (solo admin) |
-| DELETE | `/api/location-identifiers/:id` | Desactiva identificador (solo admin) |
 
 ### Cuentas
 
@@ -393,7 +377,7 @@ Todas las respuestas siguen el mismo formato de Fase 1: `{ success: boolean, dat
 - Lista de mesas y barras con estado
 - Agregar / editar / desactivar mesas
 - Agregar / editar / desactivar barras
-- Gestión de identificadores visuales de barra
+- Los identificadores de las órdenes de barra se asignan automáticamente y no requieren administración
 
 ---
 
@@ -415,7 +399,7 @@ La impresión se gestiona desde el navegador mediante `window.print()` con una h
 - **Edición de items:** confirmación explícita con descripción del cambio
 - **Cancelación de cuenta:** confirmación en dos pasos para evitar errores
 - **Transferencia:** inmediata pero con notificación push/toast al owner anterior
-- **Para llevar:** el consecutivo diario se reinicia a las 00:00 en el timezone local del negocio
+- **Consecutivos diarios** (`bar_position` y `takeout_number`): se reinician a las 00:00 en el timezone local del negocio. El reinicio es implícito: el cálculo del siguiente valor filtra por `opened_at >= inicio_del_día_local`, por lo que no requiere tarea programada
 
 ---
 
@@ -431,15 +415,13 @@ Para la notificación de transferencia de cuenta no se requiere WebSocket en Fas
 
 ### Base de Datos
 
-- [ ] Diseñar y crear migración Prisma: `locations`, `location_identifiers`, `orders`, `order_rounds`, `order_items`, `custom_extras`, `order_discounts`
-- [ ] Seed de ubicaciones iniciales (7 mesas + 1 barra con identificadores de ejemplo)
-- [ ] Seed de identificadores visuales base
+- [ ] Diseñar y crear migración Prisma: `locations`, `orders`, `order_rounds`, `order_items`, `custom_extras`, `order_discounts`
+- [ ] Seed de ubicaciones iniciales (7 mesas + 1 barra)
 
 ### Backend
 
 - [ ] CRUD `/api/locations` (con validación de tipo y estado)
-- [ ] CRUD `/api/location-identifiers`
-- [ ] `POST /api/orders` (abrir cuenta con validación de ubicación disponible)
+- [ ] `POST /api/orders` (abrir cuenta con validación de ubicación disponible; auto-asignación de `bar_position` para barra y `takeout_number` para para llevar como consecutivos diarios)
 - [ ] `GET /api/orders` (con filtro mine/all)
 - [ ] `GET /api/orders/:id` (detalle con rondas e items)
 - [ ] `POST /api/orders/:id/rounds` (nueva ronda con items)
@@ -451,7 +433,7 @@ Para la notificación de transferencia de cuenta no se requiere WebSocket en Fas
 - [ ] CRUD `/api/extras`
 - [ ] `GET /api/history` (paginado con filtros)
 - [ ] `GET /api/history/:id/ticket` (datos para reimpresión)
-- [ ] Lógica de consecutivo diario para para llevar
+- [ ] Lógica de consecutivos diarios para `bar_position` y `takeout_number` (cálculo al crear orden, sin cron)
 - [ ] Validaciones Zod para todos los endpoints nuevos
 
 ### Frontend
@@ -471,8 +453,7 @@ Para la notificación de transferencia de cuenta no se requiere WebSocket en Fas
 - [ ] Estilos `@media print` para tickets
 - [ ] Advertencias de intervención en cuenta ajena
 - [ ] Polling de cuentas activas para notificación de transferencias
-- [ ] Admin: Gestión de ubicaciones y barras
-- [ ] Admin: Gestión de identificadores visuales
+- [ ] Admin: Gestión de ubicaciones (mesas y barras)
 - [ ] Admin: Extras frecuentes
 
 ### Deploy
@@ -509,6 +490,34 @@ Para la notificación de transferencia de cuenta no se requiere WebSocket en Fas
 - El precio de un producto podría cambiar después del cobro
 - El historial debe reflejar exactamente lo que se cobró en ese momento, no recalcular
 
+### ¿Por qué no snapshotear nombres de producto, ubicación, categoría o usuario en las tablas históricas?
+
+Fase 2 entrega **reimpresión de tickets**, no reportes históricos de largo plazo. La integridad histórica completa se difiere a Fase 4 (reportes y analytics), donde el requerimiento se vuelve fuerte.
+
+**Estado actual por entidad:**
+
+| Entidad         | Referencia histórica                                  | Precio capturado              | Nombre capturado | Riesgo                       |
+| --------------- | ----------------------------------------------------- | ----------------------------- | ---------------- | ---------------------------- |
+| `products`      | `order_items.product_id`                              | ✅ `unit_price`               | ❌ JOIN          | Ticket muestra nombre actual |
+| `locations`     | `orders.location_id`                                  | n/a                           | ❌ JOIN          | Ticket muestra nombre actual |
+| `categories`    | `products.category_id` (indirecta)                    | ✅ vía `unit_price` resuelto  | ❌ JOIN          | Solo reportes por categoría  |
+| `users`         | `orders.owner_user_id`, `order_rounds.user_id`        | n/a                           | ❌ JOIN          | Solo reportes por mesero     |
+| `custom_extras` | **no es FK** — se copia a `order_items.custom_name`   | ✅ `unit_price`               | ✅ snapshot      | Ninguno                      |
+
+**Mitigaciones vigentes en Fase 2:**
+
+- Borrado lógico (`active=false`) es el default: la fila sobrevive, el FK resuelve, el ticket se renderiza igual.
+- Borrado físico (`?permanent=true`) está gated detrás de confirmación + type-to-confirm; uso excepcional.
+- Todos los precios se capturan en inserción (`order_items.unit_price`, `order_discounts.amount`).
+
+**Trade-off consciente**: si un producto / ubicación / categoría / usuario se renombra entre la transacción y una consulta posterior, se muestra el nombre actual vía JOIN. Aceptable para reimpresión de tickets del día, no para reportes históricos.
+
+**A evaluar en Fase 4** cuando se diseñe el módulo de reportes:
+
+- Snapshot de `product_name` / `location_name` en `order_items` / `orders` al momento de la inserción.
+- `ON DELETE RESTRICT` (o check a nivel de aplicación) para impedir hard-delete de filas de catálogo referenciadas desde órdenes históricas.
+- Política explícita de archivo/anonimización de usuarios con historial de ventas.
+
 ---
 
 ## 13. Señales de que Fase 2 está completa
@@ -523,12 +532,24 @@ Para la notificación de transferencia de cuenta no se requiere WebSocket en Fas
 
 ---
 
-## 14. Próximos Pasos (Fase 3)
+## 14. Próximos Pasos
+
+### Fase 3 — Operación y flujos avanzados
 
 - Control de órdenes con estatus (preparando / pendiente / cobrado)
 - Pedidos centralizados desde punto fijo (no mesero a mesa)
 - Cobro integrado al momento del pedido
 - Posible incorporación de terminal en caja registradora
+- Evaluación de WebSockets para notificaciones en tiempo real si el volumen lo justifica
+
+### Fase 4 — Reportes, analytics e integridad histórica
+
+- Reportes y analytics (ventas por período, por categoría, por mesero, productos más vendidos)
+- Snapshots de nombre de producto / ubicación en `order_items` / `orders` al momento de la inserción (ver sección 12)
+- `ON DELETE RESTRICT` o check a nivel de aplicación que impida hard-delete de filas de catálogo referenciadas por órdenes históricas
+- Política explícita de archivo / anonimización de usuarios con historial de ventas
+- Integraciones (TPV, métodos de pago, API de pedidos en línea)
+- Backup automático y exports (Excel / PDF)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,13 @@ Web app to speed up bill calculation in a seafood restaurant. Editable catalog +
 
 ## Project: Phase 2 - Bill Registration & Ticket Printing (in progress)
 
-Persistent bill management with rounds, kitchen/final ticket printing, and location-based seating. Current progress: JWT authentication with roles (ADMIN/WAITER), login page, protected routes, public menu for QR access, user CRUD, and security hardening are complete. Pending: locations (tables/bar), persistent orders with rounds, custom extras, discounts at checkout, account ownership & transfer, ticket printing (kitchen + final), order history with reprint.
+Persistent bill management with rounds, kitchen/final ticket printing, and location-based seating. Current progress: JWT authentication with roles (ADMIN/WAITER), login page, protected routes, public menu for QR access, user CRUD, security hardening, locations management (DB + backend API + admin UI — tables + bar; bar orders receive an auto-assigned daily consecutive number), and custom extras management (DB + backend API + admin UI) are complete. Pending: persistent orders with rounds, discounts at checkout, account ownership & transfer, ticket printing (kitchen + final), order history with reprint.
 
 ### Tech Stack
 
 - **Frontend:** Angular ^21.0.0, TypeScript ~5.9.2, Tailwind CSS ^4.1.12, DaisyUI ^5.5.14, Angular CDK ^21.1.3, Vitest ^4.0.8
 - **Backend:** Node.js 18+, Express.js 5.2.1, TypeScript 5.9.3, Prisma ORM 7.3.0, Zod 4.3.6, bcryptjs, jsonwebtoken, helmet, express-rate-limit, cookie-parser
-- **Database:** PostgreSQL 15+ (tables: `categories`, `products`, `users`)
+- **Database:** PostgreSQL 15+ (tables: `categories`, `products`, `users`, `custom_extras`, `locations`)
 - **Deploy:** Docker + docker-compose (dev), Koyeb (backend), Netlify/Vercel (frontend)
 
 ### Data Model
@@ -47,13 +47,17 @@ Persistent bill management with rounds, kitchen/final ticket printing, and locat
 Full menu reference in `.claude/docs/menu.mermaid.md`
 
 ```
-Category (id, name UK, description, base_price?, image, display_order, active)
-Product  (id, category_id FK, name UK, description, price?, image, display_order, customizable, active)
-User     (id, username UK, password, display_name, role [ADMIN|WAITER], active)
+Category    (id, name UK, description, base_price?, image, display_order, active)
+Product     (id, category_id FK, name UK, description, price?, image, display_order, customizable, active)
+User        (id, username UK, password, display_name, role [ADMIN|WAITER], active)
+CustomExtra (id, name UK, default_price, active, created_by FK→User?)
+Location    (id, name, type [table|bar], display_order, active)
 ```
 
 - `Category` contains `Product` (1:N)
 - `price` in Product is nullable (inherits from Category's `base_price` if not set)
+- `Location.type` is enforced as `table` or `bar` via a DB CHECK constraint
+- Bar orders receive an auto-assigned numeric identifier stored on the future `orders.bar_position` column (daily consecutive, resets at 00:00 local time). No separate identifier table is needed.
 
 ### Project Structure
 
@@ -82,6 +86,11 @@ MEPPOS/
 - `GET    /api/products` - Get all products with raw price + categories array (supports ?active=true)
 - `GET    /api/products/:id` - Get product by ID
 - `GET    /api/products/:id/price` - Get resolved price
+- `GET    /api/locations` - Get all locations (supports ?active=true)
+- `GET    /api/extras` - Get all custom extras (supports ?active=true)
+- `POST   /api/extras` - Create custom extra
+- `PUT    /api/extras/:id` - Update custom extra
+- `DELETE /api/extras/:id` - Soft delete (deactivate) extra. Hard delete with `?permanent=true`
 
 **Admin-only routes:**
 
@@ -98,6 +107,10 @@ MEPPOS/
 - `POST   /api/users` - Create user
 - `PUT    /api/users/:id` - Update user
 - `DELETE /api/users/:id` - Soft delete (deactivate) user
+- `POST   /api/locations` - Create location
+- `PUT    /api/locations/:id` - Update location
+- `DELETE /api/locations/:id` - Soft delete (deactivate) location. Hard delete with `?permanent=true`
+- `PATCH  /api/locations/reorder` - Batch reorder locations (atomic transaction)
 
 ### Reference Menu
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@
 - Official documentation of the tools and technologies used must be the primary technical reference.
 - Technical quality is the top priority: responses must be well-founded, justify decisions, and propose better alternatives when they exist, even if they contradict the initial instruction, always with solid arguments.
 - When planning or implementing any feature, proactively adopt the perspective of the relevant domain expert and surface optimizations without waiting for a second prompt. For frontend work: consider UX, accessibility, perceived performance, and feedback clarity. For backend work: consider reliability, error handling, security, and scalability. For QA/testing: consider edge cases, coverage gaps, and regression risk. Flag findings and apply high-priority improvements as part of the initial implementation.
+- **Frontend E2E tests (Playwright) run without a backend.** The CI Frontend E2E job boots only the Angular dev server; there is no Postgres and no API. Every `/api/*` request an E2E test touches MUST be stubbed via `page.route(...)` in `frontend/e2e/helpers/mocks.ts`. When adding endpoints, extend that file with a `setupXxxMocks(page)` helper and compose it with `setupApiMocks(page)` in the test's `beforeEach`. Full-stack coverage lives in the backend integration tests, not E2E.
 
 ## Project: Phase 1 - Bill Calculator
 

--- a/README.md
+++ b/README.md
@@ -335,6 +335,11 @@ npm run prisma:seed
 - **Validation**: Zod on all endpoints
 - **Type Safety**: Strict TypeScript
 
+### Testing Conventions
+
+- **Frontend E2E (Playwright) runs without a backend.** The CI job only boots the Angular dev server — no Postgres, no API. Every `/api/*` call touched by an E2E test must be stubbed via `page.route(...)` in [`frontend/e2e/helpers/mocks.ts`](frontend/e2e/helpers/mocks.ts). When adding endpoints, extend that file with a `setupXxxMocks(page)` helper and compose it with `setupApiMocks(page)` in the test's `beforeEach`.
+- **Full-stack coverage lives in backend integration tests**, not E2E: see `backend/tests/integration/` (mocked Prisma) and `backend/tests/integration-db/` (real Postgres via docker compose).
+
 ### Backend Folder Structure
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ ADMIN_DEFAULT_PASSWORD=admin123
 - `GET /api/products` - List all products with raw `price` + `categories` array (supports `?active=true`)
 - `GET /api/products/:id` - Get a product by ID
 - `GET /api/products/:id/price` - Get effective price (direct or inherited from category)
+- `GET /api/locations` - List all locations (supports `?active=true`)
+- `GET /api/extras` - List all active custom extras
+- `POST /api/extras` - Create custom extra
+- `PUT /api/extras/:id` - Update custom extra
+- `DELETE /api/extras/:id` - Soft delete (deactivate) extra. Hard delete with `?permanent=true`
 
 ### Admin-only Endpoints
 
@@ -161,6 +166,10 @@ ADMIN_DEFAULT_PASSWORD=admin123
 - `POST /api/users` - Create user
 - `PUT /api/users/:id` - Update user
 - `DELETE /api/users/:id` - Soft delete (deactivate) user
+- `POST /api/locations` - Create location
+- `PUT /api/locations/:id` - Update location
+- `DELETE /api/locations/:id` - Soft delete (deactivate) location. Hard delete with `?permanent=true`
+- `PATCH /api/locations/reorder` - Batch reorder locations (atomic transaction)
 
 #### Health Check
 
@@ -201,11 +210,13 @@ ADMIN_DEFAULT_PASSWORD=admin123
 
 ### Data Model
 
-The system uses 3 tables:
+The system uses 5 tables:
 
 1. **categories** - Product categories with optional base price
 2. **products** - Individual products that can inherit price from their category or define their own
 3. **users** - Staff accounts with roles (ADMIN, WAITER) for authentication
+4. **custom_extras** - Reusable non-catalog items (extras) with a required default price, created by any authenticated user
+5. **locations** - Physical restaurant locations: tables and bar (type enforced via DB CHECK constraint). Bar orders receive a system-assigned numeric identifier (daily consecutive) at order-creation time; no separate identifier table is required.
 
 ---
 
@@ -251,10 +262,10 @@ The system uses 3 tables:
 - ✅ CD pipeline (auto-deploy to Koyeb + Vercel on push to master after CI passes)
 - ✅ PWA auto-update: SwUpdate prompt with forced reload on new version
 - ✅ Detailed login error messages with Koyeb cold start auto-retry (exponential backoff)
-- ✅ SWR caching for settings tabs (categories, products, users) — instant tab switches, background revalidation, manual refresh
-- ⬜ Locations management (tables/bar with visual identifiers)
+- ✅ SWR caching for settings tabs (categories, products, users, locations, extras) — instant tab switches, background revalidation, manual refresh
+- ✅ Locations management (DB migrations, backend API, admin UI with drag-and-drop reorder)
+- ✅ Custom extras management (DB migration, backend API, admin UI)
 - ⬜ Persistent orders with multiple rounds
-- ⬜ Custom extras and frequent extras list
 - ⬜ Discounts at checkout (fixed/percentage)
 - ⬜ Account ownership and transfer between waiters
 - ⬜ Kitchen ticket printing (per round)
@@ -328,7 +339,7 @@ npm run prisma:seed
 
 ```bash
 backend/src/
-├── controllers/       # HTTP handlers (auth, user, category, product, menu)
+├── controllers/       # HTTP handlers (auth, user, category, product, menu, location, custom-extra)
 ├── lib/              # Shared utilities (Prisma client, display-order helpers, JWT, error handling)
 ├── middleware/        # Express middleware (auth, authorize)
 ├── services/         # Business logic
@@ -346,11 +357,11 @@ frontend/src/
 │   ├── guards/       # Route guards (auth, no-auth, unsaved changes)
 │   ├── interceptors/ # HTTP interceptors (auth, server error handling with cold start retry)
 │   ├── models/       # TypeScript interfaces
-│   ├── services/     # Angular services (auth, user, category, product, menu, theme, toast, confirm dialog, splash, pwa-update)
+│   ├── services/     # Angular services (auth, user, category, product, menu, location, custom-extra, theme, toast, confirm dialog, splash, pwa-update)
 │   └── utils/        # Utility classes (SWR cache)
 ├── environments/     # Environment configs (dev/prod)
 ├── pages/            # Page components (login, menu, bill, settings)
-│   └── settings/components/  # Settings sub-components (theme-selector, category-manager, product-manager, user-manager)
+│   └── settings/components/  # Settings sub-components (theme-selector, category-manager, product-manager, user-manager, location-manager, custom-extra-manager)
 └── shared/
     ├── components/            # Reusable UI components (toast, confirm-dialog, icon)
     └── styles/                # Shared component styles (CDK drag-drop, input resets)

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -37,6 +37,7 @@
         "supertest": "^7.2.2",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.0"
       }
@@ -199,6 +200,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@hono/node-server": {
@@ -2164,6 +2607,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2531,6 +3016,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/giget": {
@@ -4090,6 +4588,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -4788,6 +5296,26 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-is": {
       "version": "2.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -56,6 +56,7 @@
     "supertest": "^7.2.2",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.0"
   }

--- a/backend/prisma/migrations/20260418000000_add_custom_extras/migration.sql
+++ b/backend/prisma/migrations/20260418000000_add_custom_extras/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "custom_extras" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "default_price" DECIMAL(10,2) NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "created_by" INTEGER,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3),
+
+    CONSTRAINT "custom_extras_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "custom_extras_name_key" ON "custom_extras"("name");
+
+-- AddForeignKey
+ALTER TABLE "custom_extras" ADD CONSTRAINT "custom_extras_created_by_fkey" FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260418000001_add_locations/migration.sql
+++ b/backend/prisma/migrations/20260418000001_add_locations/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "locations" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(100) NOT NULL,
+    "type" VARCHAR(20) NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "display_order" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3),
+
+    CONSTRAINT "locations_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "locations_type_check" CHECK (type IN ('table', 'bar'))
+);
+
+-- CreateIndex
+CREATE INDEX "locations_display_order_idx" ON "locations"("display_order");
+
+-- CreateIndex
+CREATE INDEX "locations_active_idx" ON "locations"("active");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -28,8 +28,46 @@ model User {
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt @map("updated_at")
 
+  customExtras CustomExtra[]
+
   @@index([active])
   @@map("users")
+}
+
+// ============================================
+// PHASE 2 — EXTRAS
+// ============================================
+
+model CustomExtra {
+  id           Int       @id @default(autoincrement())
+  name         String    @unique @db.VarChar(255)
+  defaultPrice Decimal   @map("default_price") @db.Decimal(10, 2)
+  active       Boolean   @default(true)
+  createdBy    Int?      @map("created_by")
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime? @updatedAt @map("updated_at")
+
+  creator User? @relation(fields: [createdBy], references: [id])
+
+  @@map("custom_extras")
+}
+
+// ============================================
+// PHASE 2 — LOCATIONS
+// ============================================
+
+model Location {
+  id           Int       @id @default(autoincrement())
+  name         String    @db.VarChar(100)
+  type         String    @db.VarChar(20)
+  active       Boolean   @default(true)
+  displayOrder Int       @default(0) @map("display_order")
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime? @updatedAt @map("updated_at")
+
+  @@index([displayOrder])
+  @@index([active])
+  @@map("locations")
 }
 
 // ============================================

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -522,12 +522,35 @@ async function main() {
   console.log('✅ Water and juices created');
 
   // ============================================
+  // LOCATIONS
+  // ============================================
+
+  const locationCount = await prisma.location.count();
+  if (locationCount === 0) {
+    await prisma.location.createMany({
+      data: [
+        { name: 'Mesa 1', type: 'table', displayOrder: 1 },
+        { name: 'Mesa 2', type: 'table', displayOrder: 2 },
+        { name: 'Mesa 3', type: 'table', displayOrder: 3 },
+        { name: 'Mesa 4', type: 'table', displayOrder: 4 },
+        { name: 'Mesa 5', type: 'table', displayOrder: 5 },
+        { name: 'Mesa 6', type: 'table', displayOrder: 6 },
+        { name: 'Mesa 7', type: 'table', displayOrder: 7 },
+        { name: 'Barra', type: 'bar', displayOrder: 8 },
+      ],
+    });
+  }
+
+  console.log('✅ Locations created');
+
+  // ============================================
   // SUMMARY
   // ============================================
 
   const userCount = await prisma.user.count();
   const categoryCount = await prisma.category.count();
   const productCount = await prisma.product.count();
+  const finalLocationCount = await prisma.location.count();
 
   console.log('\n╔════════════════════════════════════════╗');
   console.log('║       🌱 SEED SUMMARY                  ║');
@@ -535,6 +558,7 @@ async function main() {
   console.log(`║  Users: ${userCount}                              ║`);
   console.log(`║  Categories: ${categoryCount}                          ║`);
   console.log(`║  Products: ${productCount}                           ║`);
+  console.log(`║  Locations: ${finalLocationCount}                          ║`);
   console.log('╚════════════════════════════════════════╝');
   console.log('\n✅ Seed completed successfully!');
 }

--- a/backend/src/controllers/custom-extra.controller.ts
+++ b/backend/src/controllers/custom-extra.controller.ts
@@ -1,0 +1,94 @@
+import { Request, Response } from 'express';
+import { customExtraService } from '../services/custom-extra.service';
+import { CreateCustomExtraSchema, UpdateCustomExtraSchema, CustomExtraIdSchema } from '../types/custom-extra.types';
+import { hasPrismaCode, isZodError } from '../lib/error';
+
+export class CustomExtraController {
+  async getAllExtras(req: Request, res: Response): Promise<void> {
+    try {
+      const activeOnly = req.query.active === 'true';
+      const extras = activeOnly
+        ? await customExtraService.getActiveExtras()
+        : await customExtraService.getAllExtras();
+      res.json({ success: true, data: extras, count: extras.length });
+    } catch (error) {
+      console.error('Error getting extras:', error);
+      res.status(500).json({ success: false, error: 'Failed to get extras' });
+    }
+  }
+
+  async createExtra(req: Request, res: Response): Promise<void> {
+    try {
+      const data = CreateCustomExtraSchema.parse(req.body);
+      const extra = await customExtraService.createExtra(data, req.user!.userId);
+      res.status(201).json({ success: true, data: extra, message: 'Extra created successfully' });
+    } catch (error) {
+      if (isZodError(error)) {
+        res.status(400).json({ success: false, error: 'Invalid request body' });
+        return;
+      }
+      if (hasPrismaCode(error, 'P2002')) {
+        res.status(409).json({ success: false, error: 'An extra with that name already exists' });
+        return;
+      }
+      console.error('Error creating extra:', error);
+      res.status(500).json({ success: false, error: 'Failed to create extra' });
+    }
+  }
+
+  async updateExtra(req: Request, res: Response): Promise<void> {
+    const idResult = CustomExtraIdSchema.safeParse(req.params);
+    if (!idResult.success) {
+      res.status(400).json({ success: false, error: 'Invalid extra ID' });
+      return;
+    }
+    try {
+      const data = UpdateCustomExtraSchema.parse(req.body);
+      const extra = await customExtraService.updateExtra(idResult.data.id, data);
+      res.json({ success: true, data: extra, message: 'Extra updated successfully' });
+    } catch (error) {
+      if (isZodError(error)) {
+        res.status(400).json({ success: false, error: 'Invalid request body' });
+        return;
+      }
+      if (hasPrismaCode(error, 'P2025')) {
+        res.status(404).json({ success: false, error: 'Extra not found' });
+        return;
+      }
+      if (hasPrismaCode(error, 'P2002')) {
+        res.status(409).json({ success: false, error: 'An extra with that name already exists' });
+        return;
+      }
+      console.error('Error updating extra:', error);
+      res.status(500).json({ success: false, error: 'Failed to update extra' });
+    }
+  }
+
+  async deleteExtra(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = CustomExtraIdSchema.parse(req.params);
+      const permanent = req.query.permanent === 'true';
+
+      if (permanent) {
+        await customExtraService.deleteExtra(id);
+        res.json({ success: true, message: 'Extra permanently deleted' });
+      } else {
+        await customExtraService.deactivateExtra(id);
+        res.json({ success: true, message: 'Extra deactivated successfully' });
+      }
+    } catch (error) {
+      if (isZodError(error)) {
+        res.status(400).json({ success: false, error: 'Invalid extra ID' });
+        return;
+      }
+      if (hasPrismaCode(error, 'P2025')) {
+        res.status(404).json({ success: false, error: 'Extra not found' });
+        return;
+      }
+      console.error('Error deleting extra:', error);
+      res.status(500).json({ success: false, error: 'Failed to delete extra' });
+    }
+  }
+}
+
+export const customExtraController = new CustomExtraController();

--- a/backend/src/controllers/location.controller.ts
+++ b/backend/src/controllers/location.controller.ts
@@ -1,0 +1,110 @@
+import { Request, Response } from 'express';
+import { locationService } from '../services/location.service';
+import {
+  CreateLocationSchema,
+  UpdateLocationSchema,
+  LocationIdSchema,
+  ReorderLocationsSchema,
+} from '../types/location.types';
+import { hasPrismaCode, isZodError } from '../lib/error';
+
+export class LocationController {
+  async getAllLocations(req: Request, res: Response): Promise<void> {
+    try {
+      const activeOnly = req.query.active === 'true';
+      const locations = activeOnly
+        ? await locationService.getActiveLocations()
+        : await locationService.getAllLocations();
+      res.json({ success: true, data: locations, count: locations.length });
+    } catch (error) {
+      console.error('Error getting locations:', error);
+      res.status(500).json({ success: false, error: 'Failed to get locations' });
+    }
+  }
+
+  async createLocation(req: Request, res: Response): Promise<void> {
+    try {
+      const data = CreateLocationSchema.parse(req.body);
+      const location = await locationService.createLocation(data);
+      res.status(201).json({ success: true, data: location, message: 'Location created successfully' });
+    } catch (error) {
+      if (isZodError(error)) {
+        res.status(400).json({ success: false, error: 'Invalid request body' });
+        return;
+      }
+      console.error('Error creating location:', error);
+      res.status(500).json({ success: false, error: 'Failed to create location' });
+    }
+  }
+
+  async updateLocation(req: Request, res: Response): Promise<void> {
+    const idResult = LocationIdSchema.safeParse(req.params);
+    if (!idResult.success) {
+      res.status(400).json({ success: false, error: 'Invalid location ID' });
+      return;
+    }
+    try {
+      const data = UpdateLocationSchema.parse(req.body);
+      const location = await locationService.updateLocation(idResult.data.id, data);
+      res.json({ success: true, data: location, message: 'Location updated successfully' });
+    } catch (error) {
+      if (isZodError(error)) {
+        res.status(400).json({ success: false, error: 'Invalid request body' });
+        return;
+      }
+      if (hasPrismaCode(error, 'P2025')) {
+        res.status(404).json({ success: false, error: 'Location not found' });
+        return;
+      }
+      console.error('Error updating location:', error);
+      res.status(500).json({ success: false, error: 'Failed to update location' });
+    }
+  }
+
+  async deleteLocation(req: Request, res: Response): Promise<void> {
+    try {
+      const { id } = LocationIdSchema.parse(req.params);
+      const permanent = req.query.permanent === 'true';
+
+      if (permanent) {
+        await locationService.deleteLocation(id);
+        res.json({ success: true, message: 'Location permanently deleted' });
+      } else {
+        await locationService.deactivateLocation(id);
+        res.json({ success: true, message: 'Location deactivated successfully' });
+      }
+    } catch (error) {
+      if (isZodError(error)) {
+        res.status(400).json({ success: false, error: 'Invalid location ID' });
+        return;
+      }
+      if (hasPrismaCode(error, 'P2025')) {
+        res.status(404).json({ success: false, error: 'Location not found' });
+        return;
+      }
+      console.error('Error deleting location:', error);
+      res.status(500).json({ success: false, error: 'Failed to delete location' });
+    }
+  }
+
+  async reorderLocations(req: Request, res: Response): Promise<void> {
+    try {
+      const { locationIds } = ReorderLocationsSchema.parse(req.body);
+      const updated = await locationService.reorderLocations(locationIds);
+      res.json({ success: true, message: 'Locations reordered successfully', data: { updated } });
+    } catch (error) {
+      if (isZodError(error)) {
+        res.status(400).json({ success: false, error: 'Invalid request body' });
+        return;
+      }
+      if (error instanceof Error && (error.message.includes('Invalid location IDs') || error.message.includes('Duplicate location IDs'))) {
+        res.status(400).json({ success: false, error: error.message });
+        return;
+      }
+      console.error('Error reordering locations:', error);
+      res.status(500).json({ success: false, error: 'Failed to reorder locations' });
+    }
+  }
+}
+
+export const locationController = new LocationController();

--- a/backend/src/lib/display-order.ts
+++ b/backend/src/lib/display-order.ts
@@ -9,7 +9,7 @@ type TransactionClient = Prisma.TransactionClient;
  */
 export async function closeDisplayOrderGaps(
   tx: TransactionClient,
-  model: 'category' | 'product',
+  model: 'category' | 'product' | 'location',
   filter: Record<string, unknown> = {}
 ): Promise<void> {
   const delegate = tx[model] as any;
@@ -31,7 +31,7 @@ export async function closeDisplayOrderGaps(
  * Checks for existence, scope membership, and duplicates before applying.
  */
 export async function reorderDisplayOrder(
-  model: 'category' | 'product',
+  model: 'category' | 'product' | 'location',
   ids: number[],
   filter: Record<string, unknown> = {}
 ): Promise<number> {

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -4,6 +4,8 @@ import { categoryController } from '../controllers/category.controller';
 import { productController } from '../controllers/product.controller';
 import { authController } from '../controllers/auth.controller';
 import { userController } from '../controllers/user.controller';
+import { locationController } from '../controllers/location.controller';
+import { customExtraController } from '../controllers/custom-extra.controller';
 import { authenticate, authorize } from '../middleware/auth.middleware';
 
 const router = Router();
@@ -39,6 +41,15 @@ router.get('/products', productController.getAllProducts.bind(productController)
 router.get('/products/:id', productController.getProductById.bind(productController));
 router.get('/products/:id/price', productController.getProductPrice.bind(productController));
 
+// Locations (GET — waiters need to see locations to open orders)
+router.get('/locations', locationController.getAllLocations.bind(locationController));
+
+// Custom extras (all mutations available to any authenticated user)
+router.get('/extras', customExtraController.getAllExtras.bind(customExtraController));
+router.post('/extras', customExtraController.createExtra.bind(customExtraController));
+router.put('/extras/:id', customExtraController.updateExtra.bind(customExtraController));
+router.delete('/extras/:id', customExtraController.deleteExtra.bind(customExtraController));
+
 // ============================================
 // ADMIN-ONLY ROUTES
 // ============================================
@@ -63,5 +74,11 @@ router.post('/products', productController.createProduct.bind(productController)
 router.put('/products/:id', productController.updateProduct.bind(productController));
 router.delete('/products/:id', productController.deleteProduct.bind(productController));
 router.patch('/products/reorder', productController.reorderProducts.bind(productController));
+
+// Locations (mutations — admin only)
+router.post('/locations', locationController.createLocation.bind(locationController));
+router.put('/locations/:id', locationController.updateLocation.bind(locationController));
+router.delete('/locations/:id', locationController.deleteLocation.bind(locationController));
+router.patch('/locations/reorder', locationController.reorderLocations.bind(locationController));
 
 export { router as apiRoutes };

--- a/backend/src/services/custom-extra.service.ts
+++ b/backend/src/services/custom-extra.service.ts
@@ -1,0 +1,45 @@
+import { prisma } from '../lib/prisma';
+import type { CreateCustomExtraDTO, UpdateCustomExtraDTO } from '../types/custom-extra.types';
+
+export class CustomExtraService {
+  async getAllExtras() {
+    return prisma.customExtra.findMany({
+      orderBy: { name: 'asc' },
+    });
+  }
+
+  async getActiveExtras() {
+    return prisma.customExtra.findMany({
+      where: { active: true },
+      orderBy: { name: 'asc' },
+    });
+  }
+
+  async getExtraById(id: number) {
+    return prisma.customExtra.findUnique({ where: { id } });
+  }
+
+  async createExtra(data: CreateCustomExtraDTO, createdBy: number) {
+    return prisma.customExtra.create({
+      data: {
+        name: data.name,
+        defaultPrice: data.defaultPrice,
+        createdBy,
+      },
+    });
+  }
+
+  async updateExtra(id: number, data: UpdateCustomExtraDTO) {
+    return prisma.customExtra.update({ where: { id }, data });
+  }
+
+  async deactivateExtra(id: number) {
+    return prisma.customExtra.update({ where: { id }, data: { active: false } });
+  }
+
+  async deleteExtra(id: number) {
+    return prisma.customExtra.delete({ where: { id } });
+  }
+}
+
+export const customExtraService = new CustomExtraService();

--- a/backend/src/services/location.service.ts
+++ b/backend/src/services/location.service.ts
@@ -1,0 +1,76 @@
+import { prisma } from '../lib/prisma';
+import { closeDisplayOrderGaps, reorderDisplayOrder } from '../lib/display-order';
+import type { CreateLocationDTO, UpdateLocationDTO } from '../types/location.types';
+
+export class LocationService {
+  async getAllLocations() {
+    return prisma.location.findMany({
+      orderBy: { displayOrder: 'asc' },
+    });
+  }
+
+  async getActiveLocations() {
+    return prisma.location.findMany({
+      where: { active: true },
+      orderBy: { displayOrder: 'asc' },
+    });
+  }
+
+  async getLocationById(id: number) {
+    return prisma.location.findUnique({ where: { id } });
+  }
+
+  async createLocation(data: CreateLocationDTO) {
+    const maxOrder = await prisma.location.aggregate({
+      where: { active: true },
+      _max: { displayOrder: true },
+    });
+    const nextOrder = (maxOrder._max.displayOrder ?? -1) + 1;
+
+    return prisma.location.create({
+      data: { name: data.name, type: data.type, displayOrder: nextOrder },
+    });
+  }
+
+  async updateLocation(id: number, data: UpdateLocationDTO) {
+    if (data.active === true) {
+      const current = await prisma.location.findUnique({
+        where: { id },
+        select: { active: true, displayOrder: true },
+      });
+
+      if (current && !current.active) {
+        return prisma.$transaction(async (tx) => {
+          await tx.location.updateMany({
+            where: {
+              active: true,
+              displayOrder: { gte: current.displayOrder },
+            },
+            data: { displayOrder: { increment: 1 } },
+          });
+
+          return tx.location.update({ where: { id }, data });
+        });
+      }
+    }
+
+    return prisma.location.update({ where: { id }, data });
+  }
+
+  async deactivateLocation(id: number) {
+    return prisma.$transaction(async (tx) => {
+      await tx.location.update({ where: { id }, data: { active: false } });
+      await closeDisplayOrderGaps(tx, 'location');
+    });
+  }
+
+  async deleteLocation(id: number) {
+    return prisma.location.delete({ where: { id } });
+  }
+
+  async reorderLocations(locationIds: number[]): Promise<number> {
+    return reorderDisplayOrder('location', locationIds);
+  }
+}
+
+export const locationService = new LocationService();

--- a/backend/src/types/custom-extra.types.ts
+++ b/backend/src/types/custom-extra.types.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const CreateCustomExtraSchema = z.object({
+  name: z.string().min(1).max(255),
+  defaultPrice: z.number().positive(),
+});
+
+export const UpdateCustomExtraSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  defaultPrice: z.number().positive().optional(),
+  active: z.boolean().optional(),
+});
+
+export const CustomExtraIdSchema = z.object({
+  id: z.coerce.number().int().positive(),
+});
+
+export type CreateCustomExtraDTO = z.infer<typeof CreateCustomExtraSchema>;
+export type UpdateCustomExtraDTO = z.infer<typeof UpdateCustomExtraSchema>;
+export type CustomExtraIdDTO = z.infer<typeof CustomExtraIdSchema>;

--- a/backend/src/types/location.types.ts
+++ b/backend/src/types/location.types.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+const LOCATION_TYPES = ['table', 'bar'] as const;
+
+export const CreateLocationSchema = z.object({
+  name: z.string().min(1).max(100),
+  type: z.enum(LOCATION_TYPES),
+});
+
+export const UpdateLocationSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  type: z.enum(LOCATION_TYPES).optional(),
+  displayOrder: z.number().int().min(0).optional(),
+  active: z.boolean().optional(),
+});
+
+export const LocationIdSchema = z.object({
+  id: z.coerce.number().int().positive(),
+});
+
+export const ReorderLocationsSchema = z.object({
+  locationIds: z.array(z.number().int().positive()).min(1),
+});
+
+export type CreateLocationDTO = z.infer<typeof CreateLocationSchema>;
+export type UpdateLocationDTO = z.infer<typeof UpdateLocationSchema>;
+export type LocationIdDTO = z.infer<typeof LocationIdSchema>;
+export type ReorderLocationsDTO = z.infer<typeof ReorderLocationsSchema>;

--- a/backend/tests/integration-db/custom-extras.test.ts
+++ b/backend/tests/integration-db/custom-extras.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import request from 'supertest';
+import app from '../../src/app';
+import { generateAccessToken } from '../../src/lib/jwt';
+import { resetDb, prisma } from './helpers/db';
+
+const adminToken = generateAccessToken({ userId: 1, username: 'admin', role: 'ADMIN' });
+const waiterToken = generateAccessToken({ userId: 2, username: 'waiter', role: 'WAITER' });
+
+const api = {
+  get: (path: string, token = adminToken) =>
+    request(app).get(path).set('Authorization', `Bearer ${token}`),
+  post: (path: string, body: object, token = adminToken) =>
+    request(app).post(path).set('Authorization', `Bearer ${token}`).send(body),
+  put: (path: string, body: object, token = adminToken) =>
+    request(app).put(path).set('Authorization', `Bearer ${token}`).send(body),
+  delete: (path: string, token = adminToken) =>
+    request(app).delete(path).set('Authorization', `Bearer ${token}`),
+};
+
+async function seedUser() {
+  await prisma.user.create({
+    data: { username: 'admin', password: 'placeholder', displayName: 'Admin', role: 'ADMIN' },
+  });
+  await prisma.user.create({
+    data: { username: 'waiter', password: 'placeholder', displayName: 'Waiter', role: 'WAITER' },
+  });
+}
+
+beforeEach(async () => {
+  await resetDb();
+  await seedUser();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// ----- CREATE -----
+
+describe('POST /api/extras', () => {
+  it('creates an extra with name and defaultPrice', async () => {
+    const res = await api.post('/api/extras', { name: 'Aguacate', defaultPrice: 15.5 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.name).toBe('Aguacate');
+    expect(Number(res.body.data.defaultPrice)).toBe(15.5);
+    expect(res.body.data.active).toBe(true);
+  });
+
+  it('returns 400 when defaultPrice is missing', async () => {
+    const res = await api.post('/api/extras', { name: 'Limón' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid request body');
+  });
+
+  it('returns 409 on duplicate name', async () => {
+    await api.post('/api/extras', { name: 'Limón', defaultPrice: 5 });
+    const res = await api.post('/api/extras', { name: 'Limón', defaultPrice: 5 });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('An extra with that name already exists');
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const res = await api.post('/api/extras', { defaultPrice: 5 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid request body');
+  });
+
+  it('returns 400 when defaultPrice is zero', async () => {
+    const res = await api.post('/api/extras', { name: 'Limón2', defaultPrice: 0 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid request body');
+  });
+
+  it('returns 400 when defaultPrice is negative', async () => {
+    const res = await api.post('/api/extras', { name: 'Limón3', defaultPrice: -5 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid request body');
+  });
+
+  it('WAITER can create an extra', async () => {
+    const res = await api.post('/api/extras', { name: 'Salsa', defaultPrice: 7 }, waiterToken);
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.name).toBe('Salsa');
+  });
+});
+
+// ----- READ -----
+
+describe('GET /api/extras', () => {
+  beforeEach(async () => {
+    await prisma.customExtra.createMany({
+      data: [
+        { name: 'Zanahoria', defaultPrice: 10, active: true },
+        { name: 'Aguacate', defaultPrice: 12, active: true },
+        { name: 'Obsoleto', defaultPrice: 5, active: false },
+      ],
+    });
+  });
+
+  it('returns all extras sorted alphabetically by name', async () => {
+    const res = await api.get('/api/extras');
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(3);
+    expect(res.body.data[0].name).toBe('Aguacate');
+    expect(res.body.data[1].name).toBe('Obsoleto');
+    expect(res.body.data[2].name).toBe('Zanahoria');
+  });
+
+  it('filters to active extras when ?active=true', async () => {
+    const res = await api.get('/api/extras?active=true');
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(2);
+    const names = res.body.data.map((e: any) => e.name);
+    expect(names).not.toContain('Obsoleto');
+  });
+
+  it('WAITER can read extras', async () => {
+    const res = await api.get('/api/extras', waiterToken);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await request(app).get('/api/extras');
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// ----- UPDATE -----
+
+describe('PUT /api/extras/:id', () => {
+  it('updates the name of an extra', async () => {
+    const extra = await prisma.customExtra.create({ data: { name: 'Viejo', defaultPrice: 5 } });
+
+    const res = await api.put(`/api/extras/${extra.id}`, { name: 'Nuevo' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.name).toBe('Nuevo');
+  });
+
+  it('updates defaultPrice to a new value', async () => {
+    const extra = await prisma.customExtra.create({ data: { name: 'Limón', defaultPrice: 5 } });
+
+    const res = await api.put(`/api/extras/${extra.id}`, { defaultPrice: 10 });
+
+    expect(res.status).toBe(200);
+    expect(Number(res.body.data.defaultPrice)).toBe(10);
+  });
+
+  it('rejects null defaultPrice', async () => {
+    const extra = await prisma.customExtra.create({
+      data: { name: 'LimónNull', defaultPrice: 5 },
+    });
+
+    const res = await api.put(`/api/extras/${extra.id}`, { defaultPrice: null });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid request body');
+  });
+
+  it('returns 404 for non-existent ID', async () => {
+    const res = await api.put('/api/extras/999', { name: 'X' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Extra not found');
+  });
+
+  it('returns 409 on duplicate name', async () => {
+    await prisma.customExtra.createMany({
+      data: [{ name: 'Alpha', defaultPrice: 5 }, { name: 'Beta', defaultPrice: 5 }],
+    });
+    const beta = await prisma.customExtra.findFirst({ where: { name: 'Beta' } });
+
+    const res = await api.put(`/api/extras/${beta!.id}`, { name: 'Alpha' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('An extra with that name already exists');
+  });
+});
+
+// ----- SOFT DELETE -----
+
+describe('DELETE /api/extras/:id (soft)', () => {
+  it('sets active=false in DB but does not remove the row', async () => {
+    const extra = await prisma.customExtra.create({ data: { name: 'Limón', defaultPrice: 5 } });
+
+    const res = await api.delete(`/api/extras/${extra.id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Extra deactivated successfully');
+
+    const dbExtra = await prisma.customExtra.findUnique({ where: { id: extra.id } });
+    expect(dbExtra).not.toBeNull();
+    expect(dbExtra!.active).toBe(false);
+  });
+
+  it('returns 404 for non-existent ID', async () => {
+    const res = await api.delete('/api/extras/999');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Extra not found');
+  });
+});
+
+// ----- HARD DELETE -----
+
+describe('DELETE /api/extras/:id?permanent=true', () => {
+  it('removes the row from DB entirely', async () => {
+    const extra = await prisma.customExtra.create({ data: { name: 'Limón', defaultPrice: 5 } });
+
+    const res = await api.delete(`/api/extras/${extra.id}?permanent=true`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Extra permanently deleted');
+
+    const dbExtra = await prisma.customExtra.findUnique({ where: { id: extra.id } });
+    expect(dbExtra).toBeNull();
+  });
+
+  it('returns 404 for non-existent ID', async () => {
+    const res = await api.delete('/api/extras/999?permanent=true');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Extra not found');
+  });
+});
+
+// ----- AUTH -----
+
+describe('Auth: extras are accessible to any authenticated user', () => {
+  it('WAITER can update an extra', async () => {
+    const extra = await prisma.customExtra.create({ data: { name: 'Limón', defaultPrice: 5 } });
+
+    const res = await api.put(`/api/extras/${extra.id}`, { name: 'Limón Extra' }, waiterToken);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('WAITER can soft-delete an extra', async () => {
+    const extra = await prisma.customExtra.create({ data: { name: 'Limón', defaultPrice: 5 } });
+
+    const res = await api.delete(`/api/extras/${extra.id}`, waiterToken);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 401 without token on create', async () => {
+    const res = await request(app).post('/api/extras').send({ name: 'Limón', defaultPrice: 5 });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/tests/integration-db/helpers/db.ts
+++ b/backend/tests/integration-db/helpers/db.ts
@@ -9,7 +9,7 @@ import { prisma } from '../../../src/lib/prisma';
  */
 export async function resetDb() {
   await prisma.$executeRawUnsafe(
-    'TRUNCATE TABLE "products", "categories", "users" RESTART IDENTITY CASCADE',
+    'TRUNCATE TABLE "products", "categories", "users", "custom_extras", "locations" RESTART IDENTITY CASCADE',
   );
 }
 

--- a/backend/tests/integration-db/locations.test.ts
+++ b/backend/tests/integration-db/locations.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import request from 'supertest';
+import app from '../../src/app';
+import { generateAccessToken } from '../../src/lib/jwt';
+import { resetDb, prisma } from './helpers/db';
+
+const adminToken = generateAccessToken({ userId: 1, username: 'admin', role: 'ADMIN' });
+const waiterToken = generateAccessToken({ userId: 2, username: 'waiter', role: 'WAITER' });
+
+const api = {
+  get: (path: string, token = adminToken) =>
+    request(app).get(path).set('Authorization', `Bearer ${token}`),
+  post: (path: string, body: object, token = adminToken) =>
+    request(app).post(path).set('Authorization', `Bearer ${token}`).send(body),
+  put: (path: string, body: object, token = adminToken) =>
+    request(app).put(path).set('Authorization', `Bearer ${token}`).send(body),
+  delete: (path: string, token = adminToken) =>
+    request(app).delete(path).set('Authorization', `Bearer ${token}`),
+  patch: (path: string, body: object, token = adminToken) =>
+    request(app).patch(path).set('Authorization', `Bearer ${token}`).send(body),
+};
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+// ----- CREATE -----
+
+describe('POST /api/locations', () => {
+  it('creates a table location with displayOrder 0 as the first entry', async () => {
+    const res = await api.post('/api/locations', { name: 'Mesa 1', type: 'table' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.name).toBe('Mesa 1');
+    expect(res.body.data.type).toBe('table');
+    expect(res.body.data.displayOrder).toBe(0);
+    expect(res.body.data.active).toBe(true);
+  });
+
+  it('creates a bar location', async () => {
+    const res = await api.post('/api/locations', { name: 'Barra 1', type: 'bar' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.type).toBe('bar');
+  });
+
+  it('auto-increments displayOrder for each new location', async () => {
+    await api.post('/api/locations', { name: 'Mesa 1', type: 'table' });
+    await api.post('/api/locations', { name: 'Mesa 2', type: 'table' });
+    const res = await api.post('/api/locations', { name: 'Mesa 3', type: 'table' });
+
+    expect(res.body.data.displayOrder).toBe(2);
+  });
+
+  it('returns 400 on invalid type', async () => {
+    const res = await api.post('/api/locations', { name: 'Booth 1', type: 'booth' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid request body');
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const res = await api.post('/api/locations', { type: 'table' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid request body');
+  });
+
+  it('returns 403 for WAITER', async () => {
+    const res = await api.post('/api/locations', { name: 'Mesa 1', type: 'table' }, waiterToken);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ----- READ -----
+
+describe('GET /api/locations', () => {
+  beforeEach(async () => {
+    await prisma.location.createMany({
+      data: [
+        { name: 'Mesa 1', type: 'table', displayOrder: 0, active: true },
+        { name: 'Barra 1', type: 'bar', displayOrder: 1, active: true },
+        { name: 'Mesa Inactiva', type: 'table', displayOrder: 2, active: false },
+      ],
+    });
+  });
+
+  it('returns all locations ordered by displayOrder', async () => {
+    const res = await api.get('/api/locations');
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(3);
+    expect(res.body.data[0].name).toBe('Mesa 1');
+    expect(res.body.data[1].name).toBe('Barra 1');
+    expect(res.body.data[2].name).toBe('Mesa Inactiva');
+  });
+
+  it('includes inactive locations (no active filter by default)', async () => {
+    const res = await api.get('/api/locations');
+
+    const names = res.body.data.map((l: any) => l.name);
+    expect(names).toContain('Mesa Inactiva');
+  });
+
+  it('WAITER can read locations', async () => {
+    const res = await api.get('/api/locations', waiterToken);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await request(app).get('/api/locations');
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// ----- UPDATE -----
+
+describe('PUT /api/locations/:id', () => {
+  it('updates the name of a location', async () => {
+    const loc = await prisma.location.create({
+      data: { name: 'Mesa 1', type: 'table', displayOrder: 0 },
+    });
+
+    const res = await api.put(`/api/locations/${loc.id}`, { name: 'Mesa VIP' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.name).toBe('Mesa VIP');
+  });
+
+  it('updates type from table to bar', async () => {
+    const loc = await prisma.location.create({
+      data: { name: 'Mesa 1', type: 'table', displayOrder: 0 },
+    });
+
+    const res = await api.put(`/api/locations/${loc.id}`, { type: 'bar' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.type).toBe('bar');
+  });
+
+  it('returns 404 for non-existent ID', async () => {
+    const res = await api.put('/api/locations/999', { name: 'X' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Location not found');
+  });
+
+  it('returns 400 for invalid ID format', async () => {
+    const res = await api.put('/api/locations/abc', { name: 'X' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid location ID');
+  });
+});
+
+// ----- SOFT DELETE -----
+
+describe('DELETE /api/locations/:id (soft)', () => {
+  it('sets active=false but keeps the row in DB', async () => {
+    const loc = await prisma.location.create({
+      data: { name: 'Mesa 1', type: 'table', displayOrder: 0 },
+    });
+
+    const res = await api.delete(`/api/locations/${loc.id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Location deactivated successfully');
+
+    const dbLoc = await prisma.location.findUnique({ where: { id: loc.id } });
+    expect(dbLoc).not.toBeNull();
+    expect(dbLoc!.active).toBe(false);
+  });
+
+  it('closes displayOrder gaps after deactivation', async () => {
+    await prisma.location.createMany({
+      data: [
+        { name: 'A', type: 'table', displayOrder: 0, active: true },
+        { name: 'B', type: 'table', displayOrder: 1, active: true },
+        { name: 'C', type: 'table', displayOrder: 2, active: true },
+      ],
+    });
+    const locB = await prisma.location.findFirst({ where: { name: 'B' } });
+
+    await api.delete(`/api/locations/${locB!.id}`);
+
+    const active = await prisma.location.findMany({
+      where: { active: true },
+      orderBy: { displayOrder: 'asc' },
+    });
+    expect(active).toHaveLength(2);
+    expect(active[0].name).toBe('A');
+    expect(active[0].displayOrder).toBe(0);
+    expect(active[1].name).toBe('C');
+    expect(active[1].displayOrder).toBe(1);
+  });
+
+  it('returns 404 for non-existent ID', async () => {
+    const res = await api.delete('/api/locations/999');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Location not found');
+  });
+
+  it('returns 403 for WAITER', async () => {
+    const loc = await prisma.location.create({
+      data: { name: 'Mesa 1', type: 'table', displayOrder: 0 },
+    });
+
+    const res = await api.delete(`/api/locations/${loc.id}`, waiterToken);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ----- HARD DELETE -----
+
+describe('DELETE /api/locations/:id?permanent=true', () => {
+  it('removes the row from DB entirely', async () => {
+    const loc = await prisma.location.create({
+      data: { name: 'Mesa 1', type: 'table', displayOrder: 0 },
+    });
+
+    const res = await api.delete(`/api/locations/${loc.id}?permanent=true`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Location permanently deleted');
+
+    const dbLoc = await prisma.location.findUnique({ where: { id: loc.id } });
+    expect(dbLoc).toBeNull();
+  });
+
+  it('returns 403 for WAITER', async () => {
+    const loc = await prisma.location.create({
+      data: { name: 'Mesa 1', type: 'table', displayOrder: 0 },
+    });
+
+    const res = await api.delete(`/api/locations/${loc.id}?permanent=true`, waiterToken);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ----- REORDER -----
+
+describe('PATCH /api/locations/reorder', () => {
+  it('reorders locations by setting displayOrder equal to the array index', async () => {
+    await prisma.location.createMany({
+      data: [
+        { name: 'A', type: 'table', displayOrder: 0, active: true },
+        { name: 'B', type: 'table', displayOrder: 1, active: true },
+        { name: 'C', type: 'table', displayOrder: 2, active: true },
+      ],
+    });
+    const locs = await prisma.location.findMany({ orderBy: { displayOrder: 'asc' } });
+    const [a, b, c] = locs;
+
+    const res = await api.patch('/api/locations/reorder', {
+      locationIds: [c.id, b.id, a.id],
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.updated).toBe(3);
+
+    const reordered = await prisma.location.findMany({ orderBy: { displayOrder: 'asc' } });
+    expect(reordered[0].name).toBe('C');
+    expect(reordered[1].name).toBe('B');
+    expect(reordered[2].name).toBe('A');
+  });
+
+  it('returns 400 on duplicate IDs in the request body', async () => {
+    const res = await api.patch('/api/locations/reorder', {
+      locationIds: [1, 2, 1],
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Duplicate');
+  });
+
+  it('returns 400 when IDs do not exist', async () => {
+    const res = await api.patch('/api/locations/reorder', {
+      locationIds: [999, 998],
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Invalid location IDs');
+  });
+
+  it('returns 403 for WAITER', async () => {
+    const res = await api.patch('/api/locations/reorder', { locationIds: [1] }, waiterToken);
+
+    expect(res.status).toBe(403);
+  });
+});
+

--- a/backend/tests/integration/custom-extras.test.ts
+++ b/backend/tests/integration/custom-extras.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../../src/app';
+import { customExtraService } from '../../src/services/custom-extra.service';
+import { generateAccessToken } from '../../src/lib/jwt';
+
+vi.mock('../../src/services/custom-extra.service', () => ({
+  customExtraService: {
+    getActiveExtras: vi.fn(),
+    getAllExtras: vi.fn(),
+    createExtra: vi.fn(),
+    updateExtra: vi.fn(),
+    deactivateExtra: vi.fn(),
+    deleteExtra: vi.fn(),
+  },
+}));
+
+const adminToken = generateAccessToken({ userId: 1, username: 'admin', role: 'ADMIN' });
+const waiterToken = generateAccessToken({ userId: 2, username: 'waiter', role: 'WAITER' });
+
+const mockExtra = {
+  id: 1,
+  name: 'Aguacate',
+  defaultPrice: 10,
+  active: true,
+  createdBy: 1,
+  createdAt: new Date().toISOString(),
+  updatedAt: null,
+};
+
+// ─── GET /extras ──────────────────────────────────────────────────────────────
+
+describe('GET /api/extras', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns 200 with extras list for admin', async () => {
+    vi.mocked(customExtraService.getAllExtras).mockResolvedValue([mockExtra] as any);
+
+    const res = await request(app)
+      .get('/api/extras')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.count).toBe(1);
+    expect(res.body.data[0]).toMatchObject({ id: 1, name: 'Aguacate' });
+  });
+
+  it('returns 200 for waiter (not admin-only)', async () => {
+    vi.mocked(customExtraService.getAllExtras).mockResolvedValue([mockExtra] as any);
+
+    const res = await request(app)
+      .get('/api/extras')
+      .set('Authorization', `Bearer ${waiterToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await request(app).get('/api/extras');
+
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+    expect(customExtraService.getAllExtras).not.toHaveBeenCalled();
+  });
+});
+
+// ─── POST /extras ─────────────────────────────────────────────────────────────
+
+describe('POST /api/extras', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns 400 when defaultPrice is missing', async () => {
+    const res = await request(app)
+      .post('/api/extras')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Aguacate' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(customExtraService.createExtra).not.toHaveBeenCalled();
+  });
+
+  it('creates extra with name and price', async () => {
+    const extraWithPrice = { ...mockExtra, defaultPrice: 15.5 };
+    vi.mocked(customExtraService.createExtra).mockResolvedValue(extraWithPrice as any);
+
+    const res = await request(app)
+      .post('/api/extras')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Aguacate', defaultPrice: 15.5 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(customExtraService.createExtra).toHaveBeenCalledWith(
+      { name: 'Aguacate', defaultPrice: 15.5 },
+      1,
+    );
+  });
+
+  it('allows waiter to create (not admin-only)', async () => {
+    vi.mocked(customExtraService.createExtra).mockResolvedValue(mockExtra as any);
+
+    const res = await request(app)
+      .post('/api/extras')
+      .set('Authorization', `Bearer ${waiterToken}`)
+      .send({ name: 'Aguacate', defaultPrice: 10 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(customExtraService.createExtra).toHaveBeenCalledWith({ name: 'Aguacate', defaultPrice: 10 }, 2);
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const res = await request(app)
+      .post('/api/extras')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ defaultPrice: 10 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(customExtraService.createExtra).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when name is empty string', async () => {
+    const res = await request(app)
+      .post('/api/extras')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: '' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(customExtraService.createExtra).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when defaultPrice is zero', async () => {
+    const res = await request(app)
+      .post('/api/extras')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Aguacate', defaultPrice: 0 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(customExtraService.createExtra).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when defaultPrice is negative', async () => {
+    const res = await request(app)
+      .post('/api/extras')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Aguacate', defaultPrice: -5 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(customExtraService.createExtra).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when service throws P2002 (duplicate name)', async () => {
+    vi.mocked(customExtraService.createExtra).mockRejectedValue(
+      Object.assign(new Error('Unique constraint failed'), { code: 'P2002' }),
+    );
+
+    const res = await request(app)
+      .post('/api/extras')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Aguacate', defaultPrice: 10 });
+
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('An extra with that name already exists');
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await request(app)
+      .post('/api/extras')
+      .send({ name: 'Aguacate' });
+
+    expect(res.status).toBe(401);
+    expect(customExtraService.createExtra).not.toHaveBeenCalled();
+  });
+});
+
+// ─── PUT /extras/:id ──────────────────────────────────────────────────────────
+
+describe('PUT /api/extras/:id', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('updates extra and calls service with parsed integer id', async () => {
+    const updatedExtra = { ...mockExtra, name: 'Queso' };
+    vi.mocked(customExtraService.updateExtra).mockResolvedValue(updatedExtra as any);
+
+    const res = await request(app)
+      .put('/api/extras/1')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Queso' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toMatchObject({ name: 'Queso' });
+    expect(res.body.message).toBe('Extra updated successfully');
+    expect(customExtraService.updateExtra).toHaveBeenCalledWith(1, { name: 'Queso' });
+  });
+
+  it('rejects null defaultPrice', async () => {
+    const res = await request(app)
+      .put('/api/extras/1')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ defaultPrice: null });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(customExtraService.updateExtra).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when service throws P2025 (not found)', async () => {
+    vi.mocked(customExtraService.updateExtra).mockRejectedValue(
+      Object.assign(new Error('Record not found'), { code: 'P2025' }),
+    );
+
+    const res = await request(app)
+      .put('/api/extras/99')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Ghost' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('Extra not found');
+  });
+
+  it('returns 409 when service throws P2002 (duplicate name)', async () => {
+    vi.mocked(customExtraService.updateExtra).mockRejectedValue(
+      Object.assign(new Error('Unique constraint failed'), { code: 'P2002' }),
+    );
+
+    const res = await request(app)
+      .put('/api/extras/1')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Aguacate' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('An extra with that name already exists');
+  });
+
+  it('returns 400 when id is not a valid integer', async () => {
+    const res = await request(app)
+      .put('/api/extras/abc')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Queso' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(customExtraService.updateExtra).not.toHaveBeenCalled();
+  });
+
+  it('allows waiter to update (not admin-only)', async () => {
+    vi.mocked(customExtraService.updateExtra).mockResolvedValue(mockExtra as any);
+
+    const res = await request(app)
+      .put('/api/extras/1')
+      .set('Authorization', `Bearer ${waiterToken}`)
+      .send({ name: 'Aguacate' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});
+
+// ─── DELETE /extras/:id ───────────────────────────────────────────────────────
+
+describe('DELETE /api/extras/:id', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('soft deletes by calling deactivateExtra (not deleteExtra)', async () => {
+    vi.mocked(customExtraService.deactivateExtra).mockResolvedValue(undefined as any);
+
+    const res = await request(app)
+      .delete('/api/extras/1')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe('Extra deactivated successfully');
+    expect(customExtraService.deactivateExtra).toHaveBeenCalledWith(1);
+    expect(customExtraService.deleteExtra).not.toHaveBeenCalled();
+  });
+
+  it('hard deletes with ?permanent=true by calling deleteExtra (not deactivateExtra)', async () => {
+    vi.mocked(customExtraService.deleteExtra).mockResolvedValue(undefined as any);
+
+    const res = await request(app)
+      .delete('/api/extras/1?permanent=true')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe('Extra permanently deleted');
+    expect(customExtraService.deleteExtra).toHaveBeenCalledWith(1);
+    expect(customExtraService.deactivateExtra).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when service throws P2025 (not found)', async () => {
+    vi.mocked(customExtraService.deactivateExtra).mockRejectedValue(
+      Object.assign(new Error('Record not found'), { code: 'P2025' }),
+    );
+
+    const res = await request(app)
+      .delete('/api/extras/99')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('Extra not found');
+  });
+
+  it('returns 400 when id is not a valid integer', async () => {
+    const res = await request(app)
+      .delete('/api/extras/abc')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(customExtraService.deactivateExtra).not.toHaveBeenCalled();
+    expect(customExtraService.deleteExtra).not.toHaveBeenCalled();
+  });
+
+  it('allows waiter to delete (not admin-only)', async () => {
+    vi.mocked(customExtraService.deactivateExtra).mockResolvedValue(undefined as any);
+
+    const res = await request(app)
+      .delete('/api/extras/1')
+      .set('Authorization', `Bearer ${waiterToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await request(app).delete('/api/extras/1');
+
+    expect(res.status).toBe(401);
+    expect(customExtraService.deactivateExtra).not.toHaveBeenCalled();
+    expect(customExtraService.deleteExtra).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/integration/locations.test.ts
+++ b/backend/tests/integration/locations.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import app from '../../src/app';
+import { locationService } from '../../src/services/location.service';
+import { generateAccessToken } from '../../src/lib/jwt';
+
+vi.mock('../../src/services/location.service', () => ({
+  locationService: {
+    getAllLocations: vi.fn(),
+    getActiveLocations: vi.fn(),
+    createLocation: vi.fn(),
+    updateLocation: vi.fn(),
+    deactivateLocation: vi.fn(),
+    deleteLocation: vi.fn(),
+    reorderLocations: vi.fn(),
+  },
+}));
+
+const adminToken = generateAccessToken({ userId: 1, username: 'admin', role: 'ADMIN' });
+const waiterToken = generateAccessToken({ userId: 2, username: 'waiter', role: 'WAITER' });
+
+const mockLocation = {
+  id: 1,
+  name: 'Mesa 1',
+  type: 'table',
+  active: true,
+  displayOrder: 0,
+  createdAt: new Date().toISOString(),
+  updatedAt: null,
+};
+
+// ─── GET /locations ───────────────────────────────────────────────────────────
+
+describe('GET /api/locations', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns 200 with all locations for admin', async () => {
+    vi.mocked(locationService.getAllLocations).mockResolvedValue([mockLocation] as any);
+
+    const res = await request(app)
+      .get('/api/locations')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.count).toBe(1);
+    expect(res.body.data[0]).toMatchObject({ id: 1, name: 'Mesa 1', type: 'table' });
+    expect(locationService.getAllLocations).toHaveBeenCalled();
+    expect(locationService.getActiveLocations).not.toHaveBeenCalled();
+  });
+
+  it('allows waiter to read (not admin-only)', async () => {
+    vi.mocked(locationService.getAllLocations).mockResolvedValue([mockLocation] as any);
+
+    const res = await request(app)
+      .get('/api/locations')
+      .set('Authorization', `Bearer ${waiterToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await request(app).get('/api/locations');
+
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+    expect(locationService.getAllLocations).not.toHaveBeenCalled();
+  });
+
+  it('calls getActiveLocations when ?active=true', async () => {
+    vi.mocked(locationService.getActiveLocations).mockResolvedValue([mockLocation] as any);
+
+    const res = await request(app)
+      .get('/api/locations?active=true')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(locationService.getActiveLocations).toHaveBeenCalled();
+    expect(locationService.getAllLocations).not.toHaveBeenCalled();
+  });
+});
+
+// ─── POST /locations ──────────────────────────────────────────────────────────
+
+describe('POST /api/locations', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns 403 for waiter (admin-only route)', async () => {
+    const res = await request(app)
+      .post('/api/locations')
+      .set('Authorization', `Bearer ${waiterToken}`)
+      .send({ name: 'Mesa 1', type: 'table' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.success).toBe(false);
+    expect(locationService.createLocation).not.toHaveBeenCalled();
+  });
+
+  it('creates a table location', async () => {
+    vi.mocked(locationService.createLocation).mockResolvedValue(mockLocation as any);
+
+    const res = await request(app)
+      .post('/api/locations')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Mesa 1', type: 'table' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toMatchObject({ name: 'Mesa 1', type: 'table' });
+    expect(res.body.message).toBe('Location created successfully');
+    expect(locationService.createLocation).toHaveBeenCalledWith({ name: 'Mesa 1', type: 'table' });
+  });
+
+  it('creates a bar location', async () => {
+    const barLocation = { ...mockLocation, id: 2, name: 'Barra 1', type: 'bar' };
+    vi.mocked(locationService.createLocation).mockResolvedValue(barLocation as any);
+
+    const res = await request(app)
+      .post('/api/locations')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Barra 1', type: 'bar' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toMatchObject({ name: 'Barra 1', type: 'bar' });
+  });
+
+  it('returns 400 on invalid type', async () => {
+    const res = await request(app)
+      .post('/api/locations')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Booth 1', type: 'booth' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(locationService.createLocation).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const res = await request(app)
+      .post('/api/locations')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ type: 'table' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(locationService.createLocation).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when service throws P2025', async () => {
+    vi.mocked(locationService.createLocation).mockRejectedValue(
+      Object.assign(new Error('Record not found'), { code: 'P2025' }),
+    );
+
+    const res = await request(app)
+      .post('/api/locations')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Mesa 1', type: 'table' });
+
+    expect(res.status).toBe(500);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await request(app)
+      .post('/api/locations')
+      .send({ name: 'Mesa 1', type: 'table' });
+
+    expect(res.status).toBe(401);
+    expect(locationService.createLocation).not.toHaveBeenCalled();
+  });
+});
+
+// ─── PUT /locations/:id ───────────────────────────────────────────────────────
+
+describe('PUT /api/locations/:id', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('admin can update a location', async () => {
+    const updatedLocation = { ...mockLocation, name: 'Mesa 2' };
+    vi.mocked(locationService.updateLocation).mockResolvedValue(updatedLocation as any);
+
+    const res = await request(app)
+      .put('/api/locations/1')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Mesa 2' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toMatchObject({ name: 'Mesa 2' });
+    expect(res.body.message).toBe('Location updated successfully');
+    expect(locationService.updateLocation).toHaveBeenCalledWith(1, { name: 'Mesa 2' });
+  });
+
+  it('returns 403 for waiter (admin-only route)', async () => {
+    const res = await request(app)
+      .put('/api/locations/1')
+      .set('Authorization', `Bearer ${waiterToken}`)
+      .send({ name: 'Mesa 2' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.success).toBe(false);
+    expect(locationService.updateLocation).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when service throws P2025 (not found)', async () => {
+    vi.mocked(locationService.updateLocation).mockRejectedValue(
+      Object.assign(new Error('Record not found'), { code: 'P2025' }),
+    );
+
+    const res = await request(app)
+      .put('/api/locations/99')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Ghost' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('Location not found');
+  });
+
+  it('returns 400 when id is not a valid integer', async () => {
+    const res = await request(app)
+      .put('/api/locations/abc')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'Mesa 2' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(locationService.updateLocation).not.toHaveBeenCalled();
+  });
+});
+
+// ─── DELETE /locations/:id ────────────────────────────────────────────────────
+
+describe('DELETE /api/locations/:id', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('soft deletes by calling deactivateLocation (not deleteLocation)', async () => {
+    vi.mocked(locationService.deactivateLocation).mockResolvedValue(undefined as any);
+
+    const res = await request(app)
+      .delete('/api/locations/1')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe('Location deactivated successfully');
+    expect(locationService.deactivateLocation).toHaveBeenCalledWith(1);
+    expect(locationService.deleteLocation).not.toHaveBeenCalled();
+  });
+
+  it('hard deletes with ?permanent=true by calling deleteLocation (not deactivateLocation)', async () => {
+    vi.mocked(locationService.deleteLocation).mockResolvedValue(undefined as any);
+
+    const res = await request(app)
+      .delete('/api/locations/1?permanent=true')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe('Location permanently deleted');
+    expect(locationService.deleteLocation).toHaveBeenCalledWith(1);
+    expect(locationService.deactivateLocation).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for waiter (admin-only route)', async () => {
+    const res = await request(app)
+      .delete('/api/locations/1')
+      .set('Authorization', `Bearer ${waiterToken}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body.success).toBe(false);
+    expect(locationService.deactivateLocation).not.toHaveBeenCalled();
+    expect(locationService.deleteLocation).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when service throws P2025 (not found)', async () => {
+    vi.mocked(locationService.deactivateLocation).mockRejectedValue(
+      Object.assign(new Error('Record not found'), { code: 'P2025' }),
+    );
+
+    const res = await request(app)
+      .delete('/api/locations/99')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('Location not found');
+  });
+});
+
+// ─── PATCH /locations/reorder ─────────────────────────────────────────────────
+
+describe('PATCH /api/locations/reorder', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('reorders locations and calls service with locationIds array', async () => {
+    vi.mocked(locationService.reorderLocations).mockResolvedValue(3);
+
+    const res = await request(app)
+      .patch('/api/locations/reorder')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ locationIds: [3, 1, 2] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe('Locations reordered successfully');
+    expect(res.body.data).toMatchObject({ updated: 3 });
+    expect(locationService.reorderLocations).toHaveBeenCalledWith([3, 1, 2]);
+  });
+
+  it('returns 400 when service throws Invalid location IDs error', async () => {
+    vi.mocked(locationService.reorderLocations).mockRejectedValue(
+      new Error('Invalid location IDs: 99'),
+    );
+
+    const res = await request(app)
+      .patch('/api/locations/reorder')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ locationIds: [1, 99] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toContain('Invalid location IDs');
+  });
+
+  it('returns 403 for waiter (admin-only route)', async () => {
+    const res = await request(app)
+      .patch('/api/locations/reorder')
+      .set('Authorization', `Bearer ${waiterToken}`)
+      .send({ locationIds: [1, 2] });
+
+    expect(res.status).toBe(403);
+    expect(res.body.success).toBe(false);
+    expect(locationService.reorderLocations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when locationIds is missing', async () => {
+    const res = await request(app)
+      .patch('/api/locations/reorder')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(locationService.reorderLocations).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when locationIds is empty array', async () => {
+    const res = await request(app)
+      .patch('/api/locations/reorder')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ locationIds: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(locationService.reorderLocations).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/unit/lib/display-order.test.ts
+++ b/backend/tests/unit/lib/display-order.test.ts
@@ -13,6 +13,10 @@ vi.mock('../../../src/lib/prisma', () => ({
       findMany: vi.fn(),
       update: vi.fn(),
     },
+    location: {
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
     $transaction: vi.fn(),
   },
 }));
@@ -33,6 +37,7 @@ describe('closeDisplayOrderGaps', () => {
     fakeTx = {
       category: { findMany: mockFindMany, update: mockUpdate },
       product: { findMany: mockFindMany, update: mockUpdate },
+      location: { findMany: mockFindMany, update: mockUpdate },
     };
   });
 
@@ -79,6 +84,16 @@ describe('closeDisplayOrderGaps', () => {
     await closeDisplayOrderGaps(fakeTx, 'product');
 
     expect(mockUpdate).toHaveBeenCalledWith({ where: { id: 1 }, data: { displayOrder: 0 } });
+  });
+
+  it('works with the location model', async () => {
+    mockFindMany.mockResolvedValue([{ id: 10 }, { id: 20 }]);
+
+    await closeDisplayOrderGaps(fakeTx, 'location');
+
+    expect(mockUpdate).toHaveBeenCalledTimes(2);
+    expect(mockUpdate).toHaveBeenCalledWith({ where: { id: 10 }, data: { displayOrder: 0 } });
+    expect(mockUpdate).toHaveBeenCalledWith({ where: { id: 20 }, data: { displayOrder: 1 } });
   });
 });
 
@@ -141,5 +156,28 @@ describe('reorderDisplayOrder', () => {
       where: { id: { in: [10, 20] }, active: true, categoryId: 5 },
       select: { id: true },
     });
+  });
+
+  it('works with the location model', async () => {
+    vi.mocked(prisma.location.findMany).mockResolvedValue([
+      { id: 3 }, { id: 1 }, { id: 2 },
+    ] as any);
+    vi.mocked(prisma.location.update).mockResolvedValue({} as any);
+    vi.mocked(prisma.$transaction).mockResolvedValue([]);
+
+    const count = await reorderDisplayOrder('location', [3, 1, 2]);
+
+    expect(count).toBe(3);
+    expect(prisma.location.update).toHaveBeenCalledWith({ where: { id: 3 }, data: { displayOrder: 0 } });
+    expect(prisma.location.update).toHaveBeenCalledWith({ where: { id: 1 }, data: { displayOrder: 1 } });
+    expect(prisma.location.update).toHaveBeenCalledWith({ where: { id: 2 }, data: { displayOrder: 2 } });
+  });
+
+  it('throws an error for location model when IDs are missing', async () => {
+    vi.mocked(prisma.location.findMany).mockResolvedValue([{ id: 1 }] as any);
+
+    await expect(
+      reorderDisplayOrder('location', [1, 99])
+    ).rejects.toThrow('Invalid location IDs: 99');
   });
 });

--- a/frontend/e2e/helpers/mocks.ts
+++ b/frontend/e2e/helpers/mocks.ts
@@ -1,3 +1,9 @@
+// Frontend E2E tests do NOT run against a real backend. The CI Frontend E2E
+// job only boots the Angular dev server; there is no Postgres and no API.
+// Every `/api/*` request exercised in an E2E test MUST be stubbed here with
+// `page.route(...)`. When adding a new endpoint, extend this file with a
+// setup helper and call it from the test's `beforeEach` (see
+// `settings.e2e.ts` for the compose-with-`setupApiMocks` pattern).
 import type { Page } from '@playwright/test';
 
 const API_BASE = 'http://localhost:3000/api';
@@ -140,5 +146,143 @@ export async function setupHangingRequestMocks(page: Page): Promise<void> {
 
   await page.route(`${API_BASE}/auth/login`, () => {
     // Intentionally never fulfilled — request hangs until page navigation or timeout
+  });
+}
+
+// ─── Settings page mocks ─────────────────────────────────────────────────────
+
+type MockExtra = {
+  id: number;
+  name: string;
+  defaultPrice: number | null;
+  active: boolean;
+  createdBy: number | null;
+  createdAt: string;
+  updatedAt: string | null;
+};
+
+type MockLocation = {
+  id: number;
+  name: string;
+  type: 'table' | 'bar';
+  active: boolean;
+  displayOrder: number;
+  createdAt: string;
+  updatedAt: string | null;
+};
+
+// Stubs every `/api/*` endpoint reachable from the settings page.
+// Compose on top of `setupApiMocks` (which handles login + menu). Note: the
+// test must call `setupAuthenticatedMocks(page)` AFTER logging in — doing it
+// before would make refresh succeed on the initial load and redirect the user
+// off the login page before the form renders.
+// State is held per-page and resets on each test's fresh context.
+export async function setupSettingsMocks(page: Page): Promise<void> {
+  // Empty collections for tabs the settings.e2e.ts suite does not exercise.
+  // Required because `app-category-manager` mounts by default on /settings
+  // and would otherwise hit an unmocked endpoint.
+  const emptyList = { success: true, data: [], count: 0 };
+  await page.route(`${API_BASE}/categories`, (route) =>
+    route.fulfill({ status: 200, json: emptyList }),
+  );
+  await page.route(`${API_BASE}/products`, (route) =>
+    route.fulfill({ status: 200, json: emptyList }),
+  );
+  await page.route(`${API_BASE}/users`, (route) =>
+    route.fulfill({ status: 200, json: emptyList }),
+  );
+
+  // Stateful custom extras — GET reflects prior POSTs; duplicates return 409.
+  const extras: MockExtra[] = [];
+  let nextExtraId = 1;
+  await page.route(`${API_BASE}/extras`, async (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      return route.fulfill({
+        status: 200,
+        json: { success: true, data: extras, count: extras.length },
+      });
+    }
+    if (method === 'POST') {
+      const body = JSON.parse(route.request().postData() ?? '{}') as {
+        name: string;
+        defaultPrice?: number | null;
+      };
+      if (extras.some((e) => e.name === body.name && e.active)) {
+        return route.fulfill({
+          status: 409,
+          json: { success: false, error: 'An extra with that name already exists' },
+        });
+      }
+      const created: MockExtra = {
+        id: nextExtraId++,
+        name: body.name,
+        defaultPrice: body.defaultPrice ?? null,
+        active: true,
+        createdBy: 1,
+        createdAt: new Date().toISOString(),
+        updatedAt: null,
+      };
+      extras.push(created);
+      return route.fulfill({
+        status: 201,
+        json: { success: true, data: created, message: 'Extra created successfully' },
+      });
+    }
+    return route.fallback();
+  });
+
+  // Stateful locations — pre-seeded so the "seeded data exists" test passes;
+  // POST appends and GET reflects the updated list.
+  const locations: MockLocation[] = [
+    {
+      id: 1,
+      name: 'Mesa 1',
+      type: 'table',
+      active: true,
+      displayOrder: 0,
+      createdAt: new Date().toISOString(),
+      updatedAt: null,
+    },
+    {
+      id: 2,
+      name: 'La Barra',
+      type: 'bar',
+      active: true,
+      displayOrder: 1,
+      createdAt: new Date().toISOString(),
+      updatedAt: null,
+    },
+  ];
+  let nextLocationId = 3;
+  await page.route(`${API_BASE}/locations`, async (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      return route.fulfill({
+        status: 200,
+        json: { success: true, data: locations, count: locations.length },
+      });
+    }
+    if (method === 'POST') {
+      const body = JSON.parse(route.request().postData() ?? '{}') as {
+        name: string;
+        type: 'table' | 'bar';
+      };
+      const created: MockLocation = {
+        id: nextLocationId++,
+        name: body.name,
+        type: body.type,
+        active: true,
+        displayOrder: locations.length,
+        createdAt: new Date().toISOString(),
+        updatedAt: null,
+      };
+      locations.push(created);
+      return route.fulfill({
+        status: 201,
+        json: { success: true, data: created, message: 'Location created successfully' },
+      });
+    }
+    return route.fallback();
   });
 }

--- a/frontend/e2e/settings.e2e.ts
+++ b/frontend/e2e/settings.e2e.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { setupApiMocks, setupAuthenticatedMocks, setupSettingsMocks } from './helpers/mocks';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -30,7 +31,15 @@ function listenForToast(page: Page, type: 'success' | 'error') {
 
 test.describe('Settings page — Extras & Ubicaciones tabs', () => {
   test.beforeEach(async ({ page }) => {
+    await setupApiMocks(page);
+    await setupSettingsMocks(page);
     await loginAsAdmin(page);
+    // Override refresh with a success handler AFTER login so that navigating
+    // to /settings (a full reload) restores the admin session instead of
+    // dropping the user back to the login page. If this ran before login,
+    // the app would treat the initial / load as already authenticated and
+    // skip the login form entirely.
+    await setupAuthenticatedMocks(page);
   });
 
   // ─── Extras tab ────────────────────────────────────────────────────────────
@@ -49,25 +58,12 @@ test.describe('Settings page — Extras & Ubicaciones tabs', () => {
       await expect(page.getByTestId('new-extra-submit')).toBeDisabled();
     });
 
-    test('can create a new extra with name only (no price)', async ({ page }) => {
-      const name = `SMOKE_EXTRA_${Date.now()}`;
-
+    test('create button stays disabled when price is empty', async ({ page }) => {
       await navigateToSettingsTab(page, 'Extras');
       await expect(page.locator('.loading-spinner')).not.toBeVisible({ timeout: 8_000 });
       await expandNewPanel(page, 'new-extra-toggle');
-      await page.getByTestId('new-extra-name').fill(name);
-      await expect(page.getByTestId('new-extra-submit')).toBeEnabled();
-
-      const responsePromise = page.waitForResponse(
-        (res) => res.url().includes('/api/extras') && res.request().method() === 'POST',
-      );
-      await page.getByTestId('new-extra-submit').click({ force: true });
-      const response = await responsePromise;
-      expect(response.status()).toBe(201);
-
-      await expect(
-        page.locator('[data-testid="extra-item-name"]', { hasText: name }),
-      ).toBeVisible({ timeout: 8_000 });
+      await page.getByTestId('new-extra-name').fill(`SMOKE_NO_PRICE_${Date.now()}`);
+      await expect(page.getByTestId('new-extra-submit')).toBeDisabled();
     });
 
     test('can create a new extra with name and price', async ({ page }) => {
@@ -99,6 +95,7 @@ test.describe('Settings page — Extras & Ubicaciones tabs', () => {
       await expect(page.locator('.loading-spinner')).not.toBeVisible({ timeout: 8_000 });
       await expandNewPanel(page, 'new-extra-toggle');
       await page.getByTestId('new-extra-name').fill(name);
+      await page.getByTestId('new-extra-price').fill('5.00');
 
       const firstPost = page.waitForResponse(
         (res) => res.url().includes('/api/extras') && res.request().method() === 'POST',
@@ -107,11 +104,13 @@ test.describe('Settings page — Extras & Ubicaciones tabs', () => {
       const firstRes = await firstPost;
       expect(firstRes.status()).toBe(201);
 
-      // Panel stays open after create (expandedExtraId remains 'new'); just fill the name again
       await expect(
         page.locator('[data-testid="extra-item-name"]', { hasText: name }),
       ).toBeVisible({ timeout: 8_000 });
+
+      // Panel auto-resets after a successful create; fill name + price again for the duplicate attempt
       await page.getByTestId('new-extra-name').fill(name);
+      await page.getByTestId('new-extra-price').fill('5.00');
 
       const secondPost = page.waitForResponse(
         (res) => res.url().includes('/api/extras') && res.request().method() === 'POST',

--- a/frontend/e2e/settings.e2e.ts
+++ b/frontend/e2e/settings.e2e.ts
@@ -1,0 +1,194 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function loginAsAdmin(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.locator('[data-testid="username-input"]').fill('admin');
+  await page.locator('[data-testid="password-input"]').fill('admin123');
+  await page.locator('[data-testid="login-submit"]').click();
+  await page.waitForURL('**/bill');
+}
+
+async function navigateToSettingsTab(page: Page, tabLabel: string): Promise<void> {
+  await page.goto('/settings');
+  await page.getByRole('radio', { name: tabLabel }).click();
+}
+
+async function expandNewPanel(page: Page, toggleTestId: string): Promise<void> {
+  const toggle = page.getByTestId(toggleTestId);
+  await toggle.click();
+  await expect(toggle).toBeChecked();
+}
+
+function listenForToast(page: Page, type: 'success' | 'error') {
+  const cls = type === 'success' ? '.alert-success' : '.alert-error';
+  return page.waitForSelector(cls, { state: 'visible', timeout: 8_000 });
+}
+
+// ─── Suite ───────────────────────────────────────────────────────────────────
+
+test.describe('Settings page — Extras & Ubicaciones tabs', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  // ─── Extras tab ────────────────────────────────────────────────────────────
+
+  test.describe('Extras tab', () => {
+    test('clicking the Extras tab renders the custom-extra-manager', async ({ page }) => {
+      await navigateToSettingsTab(page, 'Extras');
+      await expect(page.locator('app-custom-extra-manager')).toBeVisible();
+    });
+
+    test('create button is disabled when name is empty', async ({ page }) => {
+      await navigateToSettingsTab(page, 'Extras');
+      await expect(page.locator('app-custom-extra-manager')).toBeVisible();
+      await expect(page.locator('.loading-spinner')).not.toBeVisible({ timeout: 8_000 });
+      await expandNewPanel(page, 'new-extra-toggle');
+      await expect(page.getByTestId('new-extra-submit')).toBeDisabled();
+    });
+
+    test('can create a new extra with name only (no price)', async ({ page }) => {
+      const name = `SMOKE_EXTRA_${Date.now()}`;
+
+      await navigateToSettingsTab(page, 'Extras');
+      await expect(page.locator('.loading-spinner')).not.toBeVisible({ timeout: 8_000 });
+      await expandNewPanel(page, 'new-extra-toggle');
+      await page.getByTestId('new-extra-name').fill(name);
+      await expect(page.getByTestId('new-extra-submit')).toBeEnabled();
+
+      const responsePromise = page.waitForResponse(
+        (res) => res.url().includes('/api/extras') && res.request().method() === 'POST',
+      );
+      await page.getByTestId('new-extra-submit').click({ force: true });
+      const response = await responsePromise;
+      expect(response.status()).toBe(201);
+
+      await expect(
+        page.locator('[data-testid="extra-item-name"]', { hasText: name }),
+      ).toBeVisible({ timeout: 8_000 });
+    });
+
+    test('can create a new extra with name and price', async ({ page }) => {
+      const name = `SMOKE_EXTRA_PRICED_${Date.now()}`;
+
+      await navigateToSettingsTab(page, 'Extras');
+      await expect(page.locator('.loading-spinner')).not.toBeVisible({ timeout: 8_000 });
+      await expandNewPanel(page, 'new-extra-toggle');
+      await page.getByTestId('new-extra-name').fill(name);
+      await page.getByTestId('new-extra-price').fill('15.50');
+      await expect(page.getByTestId('new-extra-submit')).toBeEnabled();
+
+      const responsePromise = page.waitForResponse(
+        (res) => res.url().includes('/api/extras') && res.request().method() === 'POST',
+      );
+      await page.getByTestId('new-extra-submit').click({ force: true });
+      const response = await responsePromise;
+      expect(response.status()).toBe(201);
+
+      await expect(
+        page.locator('[data-testid="extra-item-name"]', { hasText: name }),
+      ).toBeVisible({ timeout: 8_000 });
+    });
+
+    test('duplicate extra name returns 409 and shows error toast', async ({ page }) => {
+      const name = `SMOKE_DUP_${Date.now()}`;
+
+      await navigateToSettingsTab(page, 'Extras');
+      await expect(page.locator('.loading-spinner')).not.toBeVisible({ timeout: 8_000 });
+      await expandNewPanel(page, 'new-extra-toggle');
+      await page.getByTestId('new-extra-name').fill(name);
+
+      const firstPost = page.waitForResponse(
+        (res) => res.url().includes('/api/extras') && res.request().method() === 'POST',
+      );
+      await page.getByTestId('new-extra-submit').click({ force: true });
+      const firstRes = await firstPost;
+      expect(firstRes.status()).toBe(201);
+
+      // Panel stays open after create (expandedExtraId remains 'new'); just fill the name again
+      await expect(
+        page.locator('[data-testid="extra-item-name"]', { hasText: name }),
+      ).toBeVisible({ timeout: 8_000 });
+      await page.getByTestId('new-extra-name').fill(name);
+
+      const secondPost = page.waitForResponse(
+        (res) => res.url().includes('/api/extras') && res.request().method() === 'POST',
+      );
+      await page.getByTestId('new-extra-submit').click({ force: true });
+      const secondRes = await secondPost;
+      expect(secondRes.status()).toBe(409);
+    });
+  });
+
+  // ─── Ubicaciones tab ───────────────────────────────────────────────────────
+
+  test.describe('Ubicaciones tab', () => {
+    test('clicking the Ubicaciones tab renders the location-manager', async ({ page }) => {
+      await navigateToSettingsTab(page, 'Ubicaciones');
+      await expect(page.locator('app-location-manager')).toBeVisible();
+    });
+
+    test('locations list is not empty (seeded data exists)', async ({ page }) => {
+      await navigateToSettingsTab(page, 'Ubicaciones');
+      await expect(page.locator('app-location-manager')).toBeVisible();
+      await expect(page.locator('app-location-manager .loading-spinner')).not.toBeVisible({
+        timeout: 8_000,
+      });
+      await expect(page.getByTestId('location-item').first()).toBeVisible({ timeout: 8_000 });
+    });
+
+    test('can create a new location with type Mesa (table)', async ({ page }) => {
+      const name = `SMOKE_MESA_${Date.now()}`;
+
+      await navigateToSettingsTab(page, 'Ubicaciones');
+      await expect(page.locator('app-location-manager .loading-spinner')).not.toBeVisible({
+        timeout: 8_000,
+      });
+      await expandNewPanel(page, 'new-location-toggle');
+      await page.getByTestId('new-location-name').fill(name);
+      await expect(page.getByTestId('new-location-type')).toHaveValue('table');
+
+      const responsePromise = page.waitForResponse(
+        (res) => res.url().includes('/api/locations') && res.request().method() === 'POST',
+      );
+      const toastPromise = listenForToast(page, 'success');
+      await page.getByTestId('new-location-submit').scrollIntoViewIfNeeded();
+      await page.getByTestId('new-location-submit').click();
+      const response = await responsePromise;
+      expect(response.status()).toBe(201);
+      await toastPromise;
+
+      await expect(
+        page.locator('[data-testid="location-item-name"]', { hasText: name }),
+      ).toBeVisible({ timeout: 8_000 });
+    });
+
+    test('can create a new location with type Barra (bar)', async ({ page }) => {
+      const name = `SMOKE_BARRA_${Date.now()}`;
+
+      await navigateToSettingsTab(page, 'Ubicaciones');
+      await expect(page.locator('app-location-manager .loading-spinner')).not.toBeVisible({
+        timeout: 8_000,
+      });
+      await expandNewPanel(page, 'new-location-toggle');
+      await page.getByTestId('new-location-name').fill(name);
+      await page.getByTestId('new-location-type').selectOption('bar');
+
+      const responsePromise = page.waitForResponse(
+        (res) => res.url().includes('/api/locations') && res.request().method() === 'POST',
+      );
+      const toastPromise = listenForToast(page, 'success');
+      await page.getByTestId('new-location-submit').scrollIntoViewIfNeeded();
+      await page.getByTestId('new-location-submit').click();
+      const response = await responsePromise;
+      expect(response.status()).toBe(201);
+      await toastPromise;
+
+      await expect(
+        page.locator('[data-testid="location-item-name"]', { hasText: name }),
+      ).toBeVisible({ timeout: 8_000 });
+    });
+  });
+});

--- a/frontend/src/core/models/custom-extra.model.ts
+++ b/frontend/src/core/models/custom-extra.model.ts
@@ -1,0 +1,25 @@
+export interface CustomExtra {
+  id: number;
+  name: string;
+  defaultPrice: number;
+  active: boolean;
+  createdBy: number | null;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+export interface CreateCustomExtraPayload {
+  name: string;
+  defaultPrice: number;
+}
+
+export interface UpdateCustomExtraPayload {
+  name?: string;
+  defaultPrice?: number;
+  active?: boolean;
+}
+
+export interface CustomExtraDraft {
+  name: string;
+  defaultPrice: string;
+}

--- a/frontend/src/core/models/index.ts
+++ b/frontend/src/core/models/index.ts
@@ -4,3 +4,5 @@ export type { ApiResponse, ProductsApiResponse } from './api-response.model';
 export type { AuthUser, LoginRequest, AuthResponse } from './auth.model';
 export type { User, Role, CreateUserPayload, UpdateUserPayload, UserDraft } from './user.model';
 export { ROLE_LABELS } from './user.model';
+export type { Location, LocationType, LocationDraft, CreateLocationPayload, UpdateLocationPayload } from './location.model';
+export type { CustomExtra, CustomExtraDraft, CreateCustomExtraPayload, UpdateCustomExtraPayload } from './custom-extra.model';

--- a/frontend/src/core/models/location.model.ts
+++ b/frontend/src/core/models/location.model.ts
@@ -1,0 +1,28 @@
+export type LocationType = 'table' | 'bar';
+
+export interface Location {
+  id: number;
+  name: string;
+  type: LocationType;
+  active: boolean;
+  displayOrder: number;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+export interface CreateLocationPayload {
+  name: string;
+  type: LocationType;
+}
+
+export interface UpdateLocationPayload {
+  name?: string;
+  type?: LocationType;
+  displayOrder?: number;
+  active?: boolean;
+}
+
+export interface LocationDraft {
+  name: string;
+  type: LocationType;
+}

--- a/frontend/src/core/services/custom-extra.service.spec.ts
+++ b/frontend/src/core/services/custom-extra.service.spec.ts
@@ -1,0 +1,186 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { CustomExtraService } from './custom-extra.service';
+import type { CustomExtra } from '../models';
+
+const BASE_URL = 'http://localhost:3000/api/extras';
+
+const EXTRA_STUB: CustomExtra = {
+  id: 1,
+  name: 'Sal',
+  defaultPrice: 10,
+  active: true,
+  createdBy: 1,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: null,
+};
+
+function flush<T>(http: HttpTestingController, url: string, data: T): void {
+  http.expectOne(url).flush({ success: true, data });
+}
+
+describe('CustomExtraService', () => {
+  let service: CustomExtraService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(CustomExtraService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  describe('signal exposure', () => {
+    it('extras, extrasLoading, extrasRevalidating, and extrasError signals are accessible', () => {
+      expect(service.extras).toBeDefined();
+      expect(service.extrasLoading).toBeDefined();
+      expect(service.extrasRevalidating).toBeDefined();
+      expect(service.extrasError).toBeDefined();
+    });
+
+    it('extras is null and extrasLoading is false before any fetch', () => {
+      expect(service.extras()).toBeNull();
+      expect(service.extrasLoading()).toBe(false);
+    });
+  });
+
+  describe('ensureExtras()', () => {
+    it('triggers GET to the extras URL', () => {
+      service.ensureExtras();
+
+      const req = http.expectOne(BASE_URL);
+      expect(req.request.method).toBe('GET');
+      req.flush({ success: true, data: [EXTRA_STUB] });
+    });
+
+    it('maps the ApiResponse envelope and populates the extras signal', () => {
+      service.ensureExtras();
+      flush(http, BASE_URL, [EXTRA_STUB]);
+
+      expect(service.extras()).toEqual([EXTRA_STUB]);
+    });
+
+    it('sets extrasLoading to true while the request is in-flight', () => {
+      service.ensureExtras();
+
+      expect(service.extrasLoading()).toBe(true);
+
+      flush(http, BASE_URL, [EXTRA_STUB]);
+      expect(service.extrasLoading()).toBe(false);
+    });
+  });
+
+  describe('refreshExtras()', () => {
+    it('always triggers GET to the extras URL even when called on a warm cache', () => {
+      service.ensureExtras();
+      flush(http, BASE_URL, [EXTRA_STUB]);
+
+      service.refreshExtras();
+
+      const req = http.expectOne(BASE_URL);
+      expect(req.request.method).toBe('GET');
+      req.flush({ success: true, data: [EXTRA_STUB] });
+    });
+
+    it('updates the extras signal with fresh data after refresh', () => {
+      service.ensureExtras();
+      flush(http, BASE_URL, [EXTRA_STUB]);
+
+      const updated: CustomExtra = { ...EXTRA_STUB, name: 'Sal actualizada' };
+      service.refreshExtras();
+      flush(http, BASE_URL, [updated]);
+
+      expect(service.extras()).toEqual([updated]);
+    });
+  });
+
+  describe('createExtra()', () => {
+    it('sends a POST to the extras URL with the given name', () => {
+      service.createExtra({ name: 'Sal', defaultPrice: 10 }).subscribe();
+
+      const req = http.expectOne(BASE_URL);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ name: 'Sal', defaultPrice: 10 });
+      req.flush({ success: true, data: EXTRA_STUB });
+    });
+
+    it('includes defaultPrice in the request body when provided', () => {
+      service.createExtra({ name: 'Sal', defaultPrice: 5 }).subscribe();
+
+      const req = http.expectOne(BASE_URL);
+      expect(req.request.body).toEqual({ name: 'Sal', defaultPrice: 5 });
+      req.flush({ success: true, data: { ...EXTRA_STUB, defaultPrice: 5 } });
+    });
+
+    it('returns the mapped CustomExtra from the ApiResponse envelope', () => {
+      let result: CustomExtra | undefined;
+      service.createExtra({ name: 'Sal', defaultPrice: 10 }).subscribe((v) => (result = v));
+
+      flush(http, BASE_URL, EXTRA_STUB);
+
+      expect(result).toEqual(EXTRA_STUB);
+    });
+  });
+
+  describe('updateExtra()', () => {
+    it('sends a PUT to the correct URL with the name payload', () => {
+      service.updateExtra(3, { name: 'Pimienta' }).subscribe();
+
+      const req = http.expectOne(`${BASE_URL}/3`);
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.body).toEqual({ name: 'Pimienta' });
+      req.flush({ success: true, data: { ...EXTRA_STUB, id: 3, name: 'Pimienta' } });
+    });
+
+    it('sends PUT with an updated defaultPrice', () => {
+      service.updateExtra(3, { defaultPrice: 25 }).subscribe();
+
+      const req = http.expectOne(`${BASE_URL}/3`);
+      expect(req.request.body).toEqual({ defaultPrice: 25 });
+      req.flush({ success: true, data: { ...EXTRA_STUB, id: 3, defaultPrice: 25 } });
+    });
+
+    it('returns the mapped CustomExtra from the ApiResponse envelope', () => {
+      const updated: CustomExtra = { ...EXTRA_STUB, id: 3, name: 'Pimienta' };
+      let result: CustomExtra | undefined;
+      service.updateExtra(3, { name: 'Pimienta' }).subscribe((v) => (result = v));
+
+      flush(http, `${BASE_URL}/3`, updated);
+
+      expect(result).toEqual(updated);
+    });
+  });
+
+  describe('deleteExtra()', () => {
+    it('sends DELETE to the correct URL without a query param when permanent is false (default)', () => {
+      service.deleteExtra(5).subscribe();
+
+      const req = http.expectOne(`${BASE_URL}/5`);
+      expect(req.request.method).toBe('DELETE');
+      expect(req.request.urlWithParams).not.toContain('permanent');
+      req.flush({ success: true, data: null });
+    });
+
+    it('sends DELETE with ?permanent=true when permanent flag is true', () => {
+      service.deleteExtra(5, true).subscribe();
+
+      const req = http.expectOne(`${BASE_URL}/5?permanent=true`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush({ success: true, data: null });
+    });
+
+    it('returns undefined (void) on success', () => {
+      let result: unknown = 'not-set';
+      service.deleteExtra(5).subscribe((v) => (result = v));
+
+      flush(http, `${BASE_URL}/5`, null);
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/core/services/custom-extra.service.ts
+++ b/frontend/src/core/services/custom-extra.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, inject, Signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, map } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { SwrCache } from '../utils/swr-cache';
+import type { ApiResponse, CustomExtra, CreateCustomExtraPayload, UpdateCustomExtraPayload } from '../models';
+
+@Injectable({ providedIn: 'root' })
+export class CustomExtraService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = `${environment.apiUrl}/extras`;
+
+  private readonly cache = new SwrCache<CustomExtra[]>({
+    fetcher: () =>
+      this.http
+        .get<ApiResponse<CustomExtra[]>>(this.baseUrl)
+        .pipe(map((r) => r.data)),
+  });
+
+  readonly extras: Signal<CustomExtra[] | null> = this.cache.data;
+  readonly extrasLoading: Signal<boolean> = this.cache.loading;
+  readonly extrasRevalidating: Signal<boolean> = this.cache.revalidating;
+  readonly extrasError: Signal<unknown> = this.cache.error;
+
+  ensureExtras(): void {
+    this.cache.ensureLoaded();
+  }
+
+  refreshExtras(): void {
+    this.cache.refreshInBackground();
+  }
+
+  createExtra(data: CreateCustomExtraPayload): Observable<CustomExtra> {
+    return this.http
+      .post<ApiResponse<CustomExtra>>(this.baseUrl, data)
+      .pipe(map((r) => r.data));
+  }
+
+  updateExtra(id: number, data: UpdateCustomExtraPayload): Observable<CustomExtra> {
+    return this.http
+      .put<ApiResponse<CustomExtra>>(`${this.baseUrl}/${id}`, data)
+      .pipe(map((r) => r.data));
+  }
+
+  deleteExtra(id: number, permanent = false): Observable<void> {
+    const url = permanent
+      ? `${this.baseUrl}/${id}?permanent=true`
+      : `${this.baseUrl}/${id}`;
+    return this.http.delete<ApiResponse<void>>(url).pipe(map(() => undefined));
+  }
+}

--- a/frontend/src/core/services/location.service.spec.ts
+++ b/frontend/src/core/services/location.service.spec.ts
@@ -1,0 +1,203 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { LocationService } from './location.service';
+import type { Location } from '../models';
+
+const LOCATIONS_URL = 'http://localhost:3000/api/locations';
+
+const LOCATION_STUB: Location = {
+  id: 1,
+  name: 'Mesa 1',
+  type: 'table',
+  active: true,
+  displayOrder: 0,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: null,
+};
+
+const LOCATION_STUB_2: Location = {
+  id: 2,
+  name: 'Mesa 2',
+  type: 'table',
+  active: true,
+  displayOrder: 1,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: null,
+};
+
+function flush<T>(http: HttpTestingController, url: string, data: T): void {
+  http.expectOne(url).flush({ success: true, data });
+}
+
+describe('LocationService', () => {
+  let service: LocationService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(LocationService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  // ─── Signal exposure ──────────────────────────────────────────────────────
+
+  describe('signal exposure', () => {
+    it('exposes locations and its loading/error signals', () => {
+      expect(service.locations).toBeDefined();
+      expect(service.locationsLoading).toBeDefined();
+      expect(service.locationsRevalidating).toBeDefined();
+      expect(service.locationsError).toBeDefined();
+    });
+
+    it('locations is null before any fetch', () => {
+      expect(service.locations()).toBeNull();
+    });
+  });
+
+  // ─── ensureLocations ──────────────────────────────────────────────────────
+
+  describe('ensureLocations()', () => {
+    it('triggers GET to the locations URL', () => {
+      service.ensureLocations();
+
+      const req = http.expectOne(LOCATIONS_URL);
+      expect(req.request.method).toBe('GET');
+      req.flush({ success: true, data: [LOCATION_STUB] });
+    });
+
+    it('maps the ApiResponse envelope and populates the locations signal', () => {
+      service.ensureLocations();
+      flush(http, LOCATIONS_URL, [LOCATION_STUB]);
+
+      expect(service.locations()).toEqual([LOCATION_STUB]);
+    });
+  });
+
+  // ─── setLocationsData ─────────────────────────────────────────────────────
+
+  describe('setLocationsData()', () => {
+    it('updates the locations signal immediately without making an HTTP request', () => {
+      service.setLocationsData([LOCATION_STUB, LOCATION_STUB_2]);
+
+      expect(service.locations()).toEqual([LOCATION_STUB, LOCATION_STUB_2]);
+      http.expectNone(LOCATIONS_URL);
+    });
+
+    it('replaces existing locations data in-place', () => {
+      service.ensureLocations();
+      flush(http, LOCATIONS_URL, [LOCATION_STUB]);
+
+      service.setLocationsData([LOCATION_STUB_2]);
+
+      expect(service.locations()).toEqual([LOCATION_STUB_2]);
+    });
+  });
+
+  // ─── createLocation ───────────────────────────────────────────────────────
+
+  describe('createLocation()', () => {
+    it('sends POST to locations URL with name and type', () => {
+      service.createLocation({ name: 'Mesa 1', type: 'table' }).subscribe();
+
+      const req = http.expectOne(LOCATIONS_URL);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ name: 'Mesa 1', type: 'table' });
+      req.flush({ success: true, data: LOCATION_STUB });
+    });
+
+    it('can create bar type', () => {
+      service.createLocation({ name: 'Barra', type: 'bar' }).subscribe();
+
+      const req = http.expectOne(LOCATIONS_URL);
+      expect(req.request.body).toEqual({ name: 'Barra', type: 'bar' });
+      req.flush({ success: true, data: { ...LOCATION_STUB, name: 'Barra', type: 'bar' } });
+    });
+
+    it('returns the mapped Location from the ApiResponse envelope', () => {
+      let result: Location | undefined;
+      service.createLocation({ name: 'Mesa 1', type: 'table' }).subscribe((v) => (result = v));
+
+      flush(http, LOCATIONS_URL, LOCATION_STUB);
+
+      expect(result).toEqual(LOCATION_STUB);
+    });
+  });
+
+  // ─── updateLocation ───────────────────────────────────────────────────────
+
+  describe('updateLocation()', () => {
+    it('sends PUT to the correct URL with the payload', () => {
+      service.updateLocation(2, { name: 'Barra' }).subscribe();
+
+      const req = http.expectOne(`${LOCATIONS_URL}/2`);
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.body).toEqual({ name: 'Barra' });
+      req.flush({ success: true, data: { ...LOCATION_STUB, id: 2, name: 'Barra' } });
+    });
+
+    it('can update the active flag', () => {
+      service.updateLocation(1, { active: true }).subscribe();
+
+      const req = http.expectOne(`${LOCATIONS_URL}/1`);
+      expect(req.request.body).toEqual({ active: true });
+      req.flush({ success: true, data: LOCATION_STUB });
+    });
+  });
+
+  // ─── deleteLocation ───────────────────────────────────────────────────────
+
+  describe('deleteLocation()', () => {
+    it('sends DELETE without query param for soft delete (default)', () => {
+      service.deleteLocation(3).subscribe();
+
+      const req = http.expectOne(`${LOCATIONS_URL}/3`);
+      expect(req.request.method).toBe('DELETE');
+      expect(req.request.urlWithParams).not.toContain('permanent');
+      req.flush({ success: true, data: null });
+    });
+
+    it('sends DELETE with ?permanent=true when flag is true', () => {
+      service.deleteLocation(3, true).subscribe();
+
+      const req = http.expectOne(`${LOCATIONS_URL}/3?permanent=true`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush({ success: true, data: null });
+    });
+
+    it('returns undefined (void) on success', () => {
+      let result: unknown = 'not-set';
+      service.deleteLocation(3).subscribe((v) => (result = v));
+
+      flush(http, `${LOCATIONS_URL}/3`, null);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  // ─── reorderLocations ─────────────────────────────────────────────────────
+
+  describe('reorderLocations()', () => {
+    it('sends PATCH to /locations/reorder with locationIds in body', () => {
+      service.reorderLocations([2, 1, 3]).subscribe();
+
+      const req = http.expectOne(`${LOCATIONS_URL}/reorder`);
+      expect(req.request.method).toBe('PATCH');
+      expect(req.request.body).toEqual({ locationIds: [2, 1, 3] });
+      req.flush({ success: true, data: { updated: 3 } });
+    });
+
+    it('preserves the exact order of IDs in the request body', () => {
+      service.reorderLocations([5, 3, 1, 2, 4]).subscribe();
+
+      const req = http.expectOne(`${LOCATIONS_URL}/reorder`);
+      expect(req.request.body.locationIds).toEqual([5, 3, 1, 2, 4]);
+      req.flush({ success: true, data: { updated: 5 } });
+    });
+  });
+});

--- a/frontend/src/core/services/location.service.ts
+++ b/frontend/src/core/services/location.service.ts
@@ -1,0 +1,66 @@
+import { Injectable, inject, Signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, map } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { SwrCache } from '../utils/swr-cache';
+import type {
+  ApiResponse,
+  Location,
+  CreateLocationPayload,
+  UpdateLocationPayload,
+} from '../models';
+
+@Injectable({ providedIn: 'root' })
+export class LocationService {
+  private readonly http = inject(HttpClient);
+  private readonly locationsUrl = `${environment.apiUrl}/locations`;
+
+  private readonly locationsCache = new SwrCache<Location[]>({
+    fetcher: () =>
+      this.http
+        .get<ApiResponse<Location[]>>(this.locationsUrl)
+        .pipe(map((r) => r.data)),
+  });
+
+  readonly locations: Signal<Location[] | null> = this.locationsCache.data;
+  readonly locationsLoading: Signal<boolean> = this.locationsCache.loading;
+  readonly locationsRevalidating: Signal<boolean> = this.locationsCache.revalidating;
+  readonly locationsError: Signal<unknown> = this.locationsCache.error;
+
+  ensureLocations(): void {
+    this.locationsCache.ensureLoaded();
+  }
+
+  refreshLocations(): void {
+    this.locationsCache.refreshInBackground();
+  }
+
+  setLocationsData(data: Location[]): void {
+    this.locationsCache.setData(data);
+  }
+
+  createLocation(data: CreateLocationPayload): Observable<Location> {
+    return this.http
+      .post<ApiResponse<Location>>(this.locationsUrl, data)
+      .pipe(map((r) => r.data));
+  }
+
+  updateLocation(id: number, data: UpdateLocationPayload): Observable<Location> {
+    return this.http
+      .put<ApiResponse<Location>>(`${this.locationsUrl}/${id}`, data)
+      .pipe(map((r) => r.data));
+  }
+
+  deleteLocation(id: number, permanent = false): Observable<void> {
+    const url = permanent
+      ? `${this.locationsUrl}/${id}?permanent=true`
+      : `${this.locationsUrl}/${id}`;
+    return this.http.delete<ApiResponse<void>>(url).pipe(map(() => undefined));
+  }
+
+  reorderLocations(locationIds: number[]): Observable<void> {
+    return this.http
+      .patch<ApiResponse<void>>(`${this.locationsUrl}/reorder`, { locationIds })
+      .pipe(map(() => undefined));
+  }
+}

--- a/frontend/src/pages/settings/components/category-manager/category-manager.html
+++ b/frontend/src/pages/settings/components/category-manager/category-manager.html
@@ -85,7 +85,7 @@
                 class="btn btn-soft btn-success"
                 title="Guardar"
                 aria-label="Guardar categoría"
-                [disabled]="!drafts[category.id]?.name?.trim() || !hasDraftChanges(category.id) || saving() === category.id"
+                [disabled]="!drafts[category.id]?.name?.trim() || !isValidDraftPrice(drafts[category.id]?.basePrice) || !hasDraftChanges(category.id) || saving() === category.id"
                 (click)="saveCategory(category)"
               >
                 @if (saving() === category.id) {
@@ -164,7 +164,7 @@
             class="btn btn-soft btn-success"
             title="Crear"
             aria-label="Crear categoría"
-            [disabled]="!newCategory.name.trim() || saving() === 'new'"
+            [disabled]="!newCategory.name.trim() || !isValidDraftPrice(newCategory.basePrice) || saving() === 'new'"
             (click)="createCategory()"
           >
             @if (saving() === 'new') {

--- a/frontend/src/pages/settings/components/category-manager/category-manager.ts
+++ b/frontend/src/pages/settings/components/category-manager/category-manager.ts
@@ -79,6 +79,7 @@ export class CategoryManagerComponent implements OnInit {
 
   createCategory(): void {
     if (!this.newCategory.name.trim()) return;
+    if (!this.isValidDraftPrice(this.newCategory.basePrice)) return;
 
     const inactive = this.inactiveCategories().find(
       (c) => c.name.toLowerCase() === this.newCategory.name.trim().toLowerCase()
@@ -127,6 +128,7 @@ export class CategoryManagerComponent implements OnInit {
   saveCategory(category: Category): void {
     const draft = this.drafts[category.id];
     if (!draft) return;
+    if (!this.isValidDraftPrice(draft.basePrice)) return;
     this.saving.set(category.id);
     const payload: UpdateCategoryPayload = {
       name: draft.name,
@@ -311,6 +313,11 @@ export class CategoryManagerComponent implements OnInit {
       this.toNumberOrNull(this.newCategory.basePrice) != null ||
       !!this.newCategory.image?.trim()
     );
+  }
+
+  isValidDraftPrice(value: unknown): boolean {
+    const price = this.toNumberOrNull(value);
+    return price === null || price >= 0;
   }
 
   resetNewCategory(): void {

--- a/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.html
+++ b/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.html
@@ -1,0 +1,190 @@
+@if (loading()) {
+  <div class="flex justify-center py-12">
+    <span class="loading loading-spinner loading-lg"></span>
+  </div>
+} @else if (error() && activeExtras().length === 0 && inactiveExtras().length === 0) {
+  <div class="alert alert-error alert-soft mt-4" role="alert">
+    <app-icon name="x-circle" />
+    <span>No se pudieron cargar los extras. Verifica tu conexión e intenta de nuevo.</span>
+    <button class="btn btn-sm btn-ghost" (click)="refresh()">Reintentar</button>
+  </div>
+} @else {
+  <div class="flex items-center justify-between mb-3">
+    <span class="text-sm text-base-content/50" aria-live="polite">
+      @if (revalidating()) { Actualizando... }
+    </span>
+    <button
+      class="btn btn-soft btn-sm gap-1"
+      aria-label="Actualizar lista"
+      [disabled]="loading() || revalidating()"
+      (click)="refresh()"
+    >
+      @if (revalidating()) {
+        <span class="loading loading-spinner loading-xs"></span>
+      } @else {
+        <app-icon name="arrow-path" sizeClass="size-4" />
+      }
+      Actualizar
+    </button>
+  </div>
+
+  <!-- Active extras -->
+  @for (extra of activeExtras(); track extra.id) {
+    <div class="collapse collapse-arrow bg-base-100 shadow-sm mb-2" data-testid="extra-item">
+      <input type="checkbox" [checked]="expandedExtraId() === extra.id" (click)="onCollapseToggle($event, extra.id)" />
+      <div class="collapse-title font-medium flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 overflow-hidden" data-testid="extra-item-name">
+        <span class="truncate">{{ extra.name }}</span>
+        <div class="flex items-center gap-2 shrink-0">
+          @if (hasDraftChanges(extra.id)) {
+            <span class="badge badge-warning badge-sm">Sin guardar</span>
+          }
+          <span class="badge badge-sm badge-success">{{ formatPrice(extra) }}</span>
+        </div>
+      </div>
+      <div class="collapse-content">
+        <div class="flex flex-col gap-3">
+          <label class="input w-full">
+            <span class="label w-28 shrink-0">Nombre *</span>
+            <input type="text" [(ngModel)]="drafts[extra.id].name" />
+          </label>
+          <label class="input w-full">
+            <span class="label w-28 shrink-0">Precio *</span>
+            <span>$</span>
+            <input type="number" min="0" step="0.01" placeholder="0.00" [(ngModel)]="drafts[extra.id].defaultPrice" />
+          </label>
+          <div class="divider my-1"></div>
+          <div class="flex gap-2">
+            <button
+              class="btn btn-soft btn-success"
+              title="Guardar"
+              [disabled]="!drafts[extra.id]?.name?.trim() || !isValidDraftPrice(drafts[extra.id]?.defaultPrice) || !hasDraftChanges(extra.id) || saving() === extra.id"
+              (click)="saveExtra(extra)"
+            >
+              @if (saving() === extra.id) {
+                <span class="loading loading-spinner loading-sm"></span>
+              } @else {
+                <app-icon name="check-circle" />
+              }
+            </button>
+            <button
+              class="btn btn-soft btn-warning"
+              title="Descartar cambios"
+              [disabled]="!hasDraftChanges(extra.id) || saving() === extra.id"
+              (click)="resetDraft(extra.id)"
+            >
+              <app-icon name="x-circle" />
+            </button>
+            <button
+              class="btn btn-soft btn-error"
+              title="Desactivar"
+              [disabled]="saving() === extra.id"
+              (click)="deactivateExtra(extra)"
+            >
+              <app-icon name="archive-down" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  }
+
+  @if (activeExtras().length === 0 && inactiveExtras().length === 0) {
+    <p class="text-base-content/60 text-center py-8">No hay extras registrados.</p>
+  }
+
+  <!-- New extra -->
+  <div class="collapse collapse-arrow bg-base-100 shadow-sm mb-2" data-testid="new-extra-panel">
+    <input type="checkbox" data-testid="new-extra-toggle" [checked]="expandedExtraId() === 'new'" (click)="onCollapseToggle($event, 'new')" />
+    <div class="collapse-title font-medium">
+      <span class="flex items-center gap-2">
+        <app-icon name="plus-circle" sizeClass="size-5 opacity-40" />
+        Nuevo extra
+      </span>
+    </div>
+    <div class="collapse-content">
+      <div class="flex flex-col gap-3">
+        <label class="input w-full">
+          <span class="label w-28 shrink-0">Nombre *</span>
+          <input type="text" data-testid="new-extra-name" [(ngModel)]="newExtra.name" autocomplete="off" />
+        </label>
+        <label class="input w-full">
+          <span class="label w-28 shrink-0">Precio *</span>
+          <span>$</span>
+          <input type="number" min="0" step="0.01" placeholder="0.00" data-testid="new-extra-price" [(ngModel)]="newExtra.defaultPriceInput" autocomplete="off" />
+        </label>
+        <div class="divider my-1"></div>
+        <div class="flex gap-2">
+          <button
+            class="btn btn-soft btn-success"
+            title="Crear"
+            data-testid="new-extra-submit"
+            [disabled]="!newExtra.name.trim() || !isValidDraftPrice(newExtra.defaultPriceInput) || saving() === 'new'"
+            (click)="createExtra()"
+          >
+            @if (saving() === 'new') {
+              <span class="loading loading-spinner loading-sm"></span>
+            } @else {
+              <app-icon name="plus-circle" />
+            }
+          </button>
+          <button
+            class="btn btn-soft btn-warning"
+            title="Descartar"
+            [disabled]="!hasDraftChanges('new') || saving() === 'new'"
+            (click)="resetDraft('new')"
+          >
+            <app-icon name="x-circle" />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Inactive extras -->
+  @if (inactiveExtras().length > 0) {
+    <div class="collapse collapse-arrow bg-base-100 mt-4">
+      <input type="checkbox" (change)="expandedInactiveId.set(null)" />
+      <div class="collapse-title text-sm font-medium flex items-center justify-between">
+        Extras desactivados
+        <span class="badge badge-sm badge-primary">{{ inactiveExtras().length }}</span>
+      </div>
+      <div class="collapse-content">
+        <div class="join join-vertical w-full">
+          @for (extra of inactiveExtras(); track extra.id) {
+            <div class="collapse collapse-arrow join-item border-base-300 border bg-base-100">
+              <input type="checkbox" [checked]="expandedInactiveId() === extra.id" (click)="expandedInactiveId.set(expandedInactiveId() === extra.id ? null : extra.id)" />
+              <div class="collapse-title font-semibold flex items-center justify-between gap-1 overflow-hidden">
+                <span class="truncate">{{ extra.name }}</span>
+                <span class="badge badge-sm badge-ghost">{{ formatPrice(extra) }}</span>
+              </div>
+              <div class="collapse-content">
+                <div class="flex gap-2">
+                  <button
+                    class="btn btn-soft btn-error"
+                    title="Eliminar permanentemente"
+                    [disabled]="saving() === extra.id"
+                    (click)="permanentDeleteExtra(extra)"
+                  >
+                    <app-icon name="trash" />
+                  </button>
+                  <button
+                    class="btn btn-soft btn-success"
+                    title="Reactivar"
+                    [disabled]="saving() === extra.id"
+                    (click)="reactivateExtra(extra)"
+                  >
+                    @if (saving() === extra.id) {
+                      <span class="loading loading-spinner loading-sm"></span>
+                    } @else {
+                      <app-icon name="upload" />
+                    }
+                  </button>
+                </div>
+              </div>
+            </div>
+          }
+        </div>
+      </div>
+    </div>
+  }
+}

--- a/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.spec.ts
+++ b/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.spec.ts
@@ -1,0 +1,354 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { Subject } from 'rxjs';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CustomExtraManagerComponent } from './custom-extra-manager';
+import { CustomExtraService } from '../../../../core/services/custom-extra.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
+import type { CustomExtra } from '../../../../core/models';
+
+const EXTRA_1: CustomExtra = {
+  id: 1,
+  name: 'Aguacate',
+  defaultPrice: 15,
+  active: true,
+  createdBy: 1,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: null,
+};
+
+const EXTRA_2: CustomExtra = {
+  id: 2,
+  name: 'Limón',
+  defaultPrice: 8,
+  active: true,
+  createdBy: 1,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: null,
+};
+
+describe('CustomExtraManagerComponent', () => {
+  let fixture: ComponentFixture<CustomExtraManagerComponent>;
+  let component: CustomExtraManagerComponent;
+
+  let extrasData: ReturnType<typeof signal<CustomExtra[] | null>>;
+  let createExtraSubject: Subject<CustomExtra>;
+  let updateExtraSubject: Subject<CustomExtra>;
+  let deleteExtraSubject: Subject<void>;
+
+  let customExtraServiceMock: any;
+  let toastServiceMock: { success: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+  let confirmDialogServiceMock: { confirm: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    extrasData = signal<CustomExtra[] | null>(null);
+    createExtraSubject = new Subject();
+    updateExtraSubject = new Subject();
+    deleteExtraSubject = new Subject();
+
+    customExtraServiceMock = {
+      extras: extrasData.asReadonly(),
+      extrasLoading: signal(false).asReadonly(),
+      extrasRevalidating: signal(false).asReadonly(),
+      extrasError: signal<unknown>(null).asReadonly(),
+      ensureExtras: vi.fn(),
+      refreshExtras: vi.fn(),
+      createExtra: vi.fn().mockReturnValue(createExtraSubject.asObservable()),
+      updateExtra: vi.fn().mockReturnValue(updateExtraSubject.asObservable()),
+      deleteExtra: vi.fn().mockReturnValue(deleteExtraSubject.asObservable()),
+    };
+
+    toastServiceMock = { success: vi.fn(), error: vi.fn() };
+    confirmDialogServiceMock = { confirm: vi.fn().mockResolvedValue(true) };
+
+    await TestBed.configureTestingModule({
+      imports: [CustomExtraManagerComponent],
+      providers: [
+        { provide: CustomExtraService, useValue: customExtraServiceMock },
+        { provide: ToastService, useValue: toastServiceMock },
+        { provide: ConfirmDialogService, useValue: confirmDialogServiceMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CustomExtraManagerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  // ─── Lifecycle ────────────────────────────────────────────────────────────
+
+  describe('ngOnInit', () => {
+    it('calls ensureExtras on initialization', () => {
+      expect(customExtraServiceMock.ensureExtras).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── formatPrice ─────────────────────────────────────────────────────────
+
+  describe('formatPrice()', () => {
+    it('returns "$15.00" when defaultPrice is 15', () => {
+      expect(component.formatPrice(EXTRA_1)).toBe('$15.00');
+    });
+
+    it('formats decimal prices with two decimal places', () => {
+      const extra: CustomExtra = { ...EXTRA_1, defaultPrice: 9.5 };
+      expect(component.formatPrice(extra)).toBe('$9.50');
+    });
+  });
+
+  // ─── parsePrice (via hasDraftChanges) ────────────────────────────────────
+
+  describe('parsePrice() (private — tested through hasDraftChanges)', () => {
+    it('treats empty string as null (differs from stored 8 → changed)', () => {
+      extrasData.set([EXTRA_2]);
+      TestBed.flushEffects();
+      component.drafts[EXTRA_2.id].defaultPrice = '';
+      expect(component.hasDraftChanges(EXTRA_2.id)).toBe(true);
+    });
+
+    it('treats non-numeric input as null (differs from stored 8 → changed)', () => {
+      extrasData.set([EXTRA_2]);
+      TestBed.flushEffects();
+      component.drafts[EXTRA_2.id].defaultPrice = 'abc';
+      expect(component.hasDraftChanges(EXTRA_2.id)).toBe(true);
+    });
+
+    it('treats negative input as null (differs from stored 8 → changed)', () => {
+      extrasData.set([EXTRA_2]);
+      TestBed.flushEffects();
+      component.drafts[EXTRA_2.id].defaultPrice = '-5';
+      expect(component.hasDraftChanges(EXTRA_2.id)).toBe(true);
+    });
+  });
+
+  // ─── hasDraftChanges ─────────────────────────────────────────────────────
+
+  describe('hasDraftChanges()', () => {
+    describe('for "new" extra', () => {
+      it('returns false when name and price are empty', () => {
+        component.newExtra = { name: '', defaultPriceInput: '' };
+        expect(component.hasDraftChanges('new')).toBe(false);
+      });
+
+      it('returns true when name is non-empty', () => {
+        component.newExtra = { name: 'Test', defaultPriceInput: '' };
+        expect(component.hasDraftChanges('new')).toBe(true);
+      });
+
+      it('returns true when price input is non-empty even if name is empty', () => {
+        component.newExtra = { name: '', defaultPriceInput: '10' };
+        expect(component.hasDraftChanges('new')).toBe(true);
+      });
+
+      it('returns false for whitespace-only name', () => {
+        component.newExtra = { name: '   ', defaultPriceInput: '' };
+        expect(component.hasDraftChanges('new')).toBe(false);
+      });
+    });
+
+    describe('for existing extra', () => {
+      beforeEach(() => {
+        extrasData.set([EXTRA_1]);
+        TestBed.flushEffects();
+      });
+
+      it('returns false when draft matches original', () => {
+        expect(component.hasDraftChanges(EXTRA_1.id)).toBe(false);
+      });
+
+      it('returns true when name has changed', () => {
+        component.drafts[EXTRA_1.id].name = 'Nuevo nombre';
+        expect(component.hasDraftChanges(EXTRA_1.id)).toBe(true);
+      });
+
+      it('returns true when price has changed', () => {
+        component.drafts[EXTRA_1.id].defaultPrice = '20';
+        expect(component.hasDraftChanges(EXTRA_1.id)).toBe(true);
+      });
+
+      it('returns true when price is cleared (15 → null)', () => {
+        component.drafts[EXTRA_1.id].defaultPrice = '';
+        expect(component.hasDraftChanges(EXTRA_1.id)).toBe(true);
+      });
+
+      it('returns false for unknown id (no draft or original)', () => {
+        expect(component.hasDraftChanges(999)).toBe(false);
+      });
+    });
+  });
+
+  // ─── createExtra ─────────────────────────────────────────────────────────
+
+  describe('createExtra()', () => {
+    it('is a no-op when name is empty', () => {
+      component.newExtra = { name: '', defaultPriceInput: '' };
+      component.createExtra();
+      expect(customExtraServiceMock.createExtra).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when name is whitespace-only', () => {
+      component.newExtra = { name: '   ', defaultPriceInput: '' };
+      component.createExtra();
+      expect(customExtraServiceMock.createExtra).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when price input is empty', () => {
+      component.newExtra = { name: 'Sal', defaultPriceInput: '' };
+      component.createExtra();
+      expect(customExtraServiceMock.createExtra).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when price input is invalid/non-numeric', () => {
+      component.newExtra = { name: 'Sal', defaultPriceInput: 'gratis' };
+      component.createExtra();
+      expect(customExtraServiceMock.createExtra).not.toHaveBeenCalled();
+    });
+
+    it('calls createExtra with trimmed name and defaultPrice', () => {
+      component.newExtra = { name: '  Sal  ', defaultPriceInput: '5.50' };
+      component.createExtra();
+      expect(customExtraServiceMock.createExtra).toHaveBeenCalledWith({ name: 'Sal', defaultPrice: 5.5 });
+    });
+
+    it('sets saving to "new" while the request is in-flight', () => {
+      component.newExtra = { name: 'Sal', defaultPriceInput: '3' };
+      component.createExtra();
+      expect(component.saving()).toBe('new');
+    });
+
+    it('resets form, saving, and calls refreshExtras on success', () => {
+      component.newExtra = { name: 'Sal', defaultPriceInput: '3' };
+      component.createExtra();
+
+      createExtraSubject.next({ ...EXTRA_1, name: 'Sal', defaultPrice: 3 });
+      createExtraSubject.complete();
+
+      expect(component.saving()).toBeNull();
+      expect(component.newExtra.name).toBe('');
+      expect(component.newExtra.defaultPriceInput).toBe('');
+      expect(customExtraServiceMock.refreshExtras).toHaveBeenCalledTimes(1);
+      expect(toastServiceMock.success).toHaveBeenCalledWith('Extra creado');
+    });
+
+    it('resets saving and shows error toast on failure', () => {
+      component.newExtra = { name: 'Sal', defaultPriceInput: '3' };
+      component.createExtra();
+
+      createExtraSubject.error(new Error('Network error'));
+
+      expect(component.saving()).toBeNull();
+      expect(toastServiceMock.error).toHaveBeenCalledWith('Error al crear extra');
+      expect(customExtraServiceMock.refreshExtras).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── saveExtra ────────────────────────────────────────────────────────────
+
+  describe('saveExtra()', () => {
+    beforeEach(() => {
+      extrasData.set([EXTRA_1]);
+      TestBed.flushEffects();
+    });
+
+    it('calls updateExtra with the correct id, name, and parsed price', () => {
+      component.drafts[EXTRA_1.id].name = 'Aguacate Hass';
+      component.drafts[EXTRA_1.id].defaultPrice = '20';
+      component.saveExtra(EXTRA_1);
+
+      expect(customExtraServiceMock.updateExtra).toHaveBeenCalledWith(EXTRA_1.id, {
+        name: 'Aguacate Hass',
+        defaultPrice: 20,
+      });
+    });
+
+    it('is a no-op when price input is empty', () => {
+      component.drafts[EXTRA_1.id].defaultPrice = '';
+      component.saveExtra(EXTRA_1);
+
+      expect(customExtraServiceMock.updateExtra).not.toHaveBeenCalled();
+    });
+
+    it('sets saving to the extra id while in-flight', () => {
+      component.drafts[EXTRA_1.id].defaultPrice = '20';
+      component.saveExtra(EXTRA_1);
+      expect(component.saving()).toBe(EXTRA_1.id);
+    });
+
+    it('resets saving and calls refreshExtras on success', () => {
+      component.drafts[EXTRA_1.id].defaultPrice = '20';
+      component.saveExtra(EXTRA_1);
+      updateExtraSubject.next(EXTRA_1);
+      updateExtraSubject.complete();
+
+      expect(component.saving()).toBeNull();
+      expect(customExtraServiceMock.refreshExtras).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── hasUnsavedChanges / discardChanges ───────────────────────────────────
+
+  describe('hasUnsavedChanges()', () => {
+    it('returns false when no extra is expanded', () => {
+      component.expandedExtraId.set(null);
+      expect(component.hasUnsavedChanges()).toBe(false);
+    });
+
+    it('returns false when "new" is expanded but form is empty', () => {
+      component.expandedExtraId.set('new');
+      component.newExtra = { name: '', defaultPriceInput: '' };
+      expect(component.hasUnsavedChanges()).toBe(false);
+    });
+
+    it('returns true when expanded extra has unsaved draft changes', () => {
+      extrasData.set([EXTRA_1]);
+      TestBed.flushEffects();
+      component.expandedExtraId.set(EXTRA_1.id);
+      component.drafts[EXTRA_1.id].name = 'Changed';
+
+      expect(component.hasUnsavedChanges()).toBe(true);
+    });
+  });
+
+  describe('discardChanges()', () => {
+    it('resets the draft to original and clears expandedExtraId', () => {
+      extrasData.set([EXTRA_1]);
+      TestBed.flushEffects();
+      component.expandedExtraId.set(EXTRA_1.id);
+      component.drafts[EXTRA_1.id].name = 'Changed';
+
+      component.discardChanges();
+
+      expect(component.drafts[EXTRA_1.id].name).toBe(EXTRA_1.name);
+      expect(component.expandedExtraId()).toBeNull();
+    });
+
+    it('does nothing when no extra is expanded', () => {
+      component.expandedExtraId.set(null);
+      component.discardChanges();
+      expect(component.expandedExtraId()).toBeNull();
+    });
+  });
+
+  // ─── computed signals ─────────────────────────────────────────────────────
+
+  describe('activeExtras / inactiveExtras computed', () => {
+    it('separates active from inactive extras', () => {
+      const inactive: CustomExtra = { ...EXTRA_1, id: 3, active: false };
+      extrasData.set([EXTRA_1, EXTRA_2, inactive]);
+      TestBed.flushEffects();
+
+      expect(component.activeExtras()).toHaveLength(2);
+      expect(component.inactiveExtras()).toHaveLength(1);
+      expect(component.inactiveExtras()[0].id).toBe(3);
+    });
+
+    it('sorts active extras alphabetically by name', () => {
+      extrasData.set([EXTRA_2, EXTRA_1]); // Limón, Aguacate — should sort to Aguacate, Limón
+      TestBed.flushEffects();
+
+      expect(component.activeExtras()[0].name).toBe('Aguacate');
+      expect(component.activeExtras()[1].name).toBe('Limón');
+    });
+  });
+});

--- a/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.ts
+++ b/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.ts
@@ -1,0 +1,257 @@
+import { Component, computed, effect, inject, OnInit, signal, untracked } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { CustomExtraService } from '../../../../core/services/custom-extra.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
+import { IconComponent } from '../../../../shared/components/icon';
+import type { CustomExtra, CustomExtraDraft, CreateCustomExtraPayload } from '../../../../core/models';
+
+@Component({
+  selector: 'app-custom-extra-manager',
+  imports: [FormsModule, IconComponent],
+  templateUrl: './custom-extra-manager.html',
+  styleUrl: '../../../../shared/styles/manager.css',
+})
+export class CustomExtraManagerComponent implements OnInit {
+  private readonly customExtraService = inject(CustomExtraService);
+  private readonly toastService = inject(ToastService);
+  private readonly confirmDialogService = inject(ConfirmDialogService);
+
+  readonly loading = this.customExtraService.extrasLoading;
+  readonly revalidating = this.customExtraService.extrasRevalidating;
+  readonly error = this.customExtraService.extrasError;
+  private readonly extrasSignal = this.customExtraService.extras;
+
+  saving = signal<number | 'new' | null>(null);
+  expandedExtraId = signal<number | 'new' | null>(null);
+  expandedInactiveId = signal<number | null>(null);
+
+  activeExtras = computed(() =>
+    (this.extrasSignal() ?? [])
+      .filter((e) => e.active)
+      .sort((a, b) => a.name.localeCompare(b.name))
+  );
+
+  inactiveExtras = computed(() =>
+    (this.extrasSignal() ?? [])
+      .filter((e) => !e.active)
+      .sort((a, b) => a.name.localeCompare(b.name))
+  );
+
+  drafts: Record<number, CustomExtraDraft> = {};
+  newExtra: { name: string; defaultPriceInput: string } = this.emptyExtra();
+
+  constructor() {
+    effect(() => {
+      const items = this.extrasSignal();
+      if (!items) return;
+      untracked(() => {
+        const ids = new Set(items.map((e) => e.id));
+        for (const item of items) {
+          if (!this.drafts[item.id] || !this.hasDraftChanges(item.id)) {
+            this.drafts[item.id] = this.toDraft(item);
+          }
+        }
+        for (const id of Object.keys(this.drafts)) {
+          if (!ids.has(Number(id))) delete this.drafts[Number(id)];
+        }
+      });
+    });
+  }
+
+  ngOnInit(): void {
+    this.customExtraService.ensureExtras();
+  }
+
+  refresh(): void {
+    this.customExtraService.refreshExtras();
+  }
+
+  createExtra(): void {
+    if (!this.newExtra.name.trim()) return;
+    const price = this.parsePrice(this.newExtra.defaultPriceInput);
+    if (price === null) return;
+    this.saving.set('new');
+    const payload: CreateCustomExtraPayload = { name: this.newExtra.name.trim(), defaultPrice: price };
+
+    this.customExtraService.createExtra(payload).subscribe({
+      next: () => {
+        this.newExtra = this.emptyExtra();
+        this.saving.set(null);
+        this.toastService.success('Extra creado');
+        this.customExtraService.refreshExtras();
+      },
+      error: () => {
+        this.toastService.error('Error al crear extra');
+        this.saving.set(null);
+      },
+    });
+  }
+
+  saveExtra(extra: CustomExtra): void {
+    const draft = this.drafts[extra.id];
+    if (!draft) return;
+    const price = this.parsePrice(draft.defaultPrice);
+    if (price === null) return;
+    this.saving.set(extra.id);
+    this.customExtraService.updateExtra(extra.id, {
+      name: draft.name,
+      defaultPrice: price,
+    }).subscribe({
+      next: () => {
+        this.saving.set(null);
+        this.toastService.success('Extra actualizado');
+        this.customExtraService.refreshExtras();
+      },
+      error: () => {
+        this.toastService.error('Error al actualizar extra');
+        this.saving.set(null);
+      },
+    });
+  }
+
+  async deactivateExtra(extra: CustomExtra): Promise<void> {
+    const confirmed = await this.confirmDialogService.confirm({
+      title: 'Desactivar extra',
+      message: `Se desactivará "${extra.name}". ¿Desea continuar?`,
+      confirmText: 'Desactivar',
+    });
+    if (!confirmed) return;
+    this.saving.set(extra.id);
+    this.customExtraService.deleteExtra(extra.id).subscribe({
+      next: () => {
+        this.saving.set(null);
+        this.toastService.success('Extra desactivado');
+        this.customExtraService.refreshExtras();
+      },
+      error: () => {
+        this.toastService.error('Error al desactivar extra');
+        this.saving.set(null);
+      },
+    });
+  }
+
+  reactivateExtra(extra: CustomExtra): void {
+    this.saving.set(extra.id);
+    this.customExtraService.updateExtra(extra.id, { active: true }).subscribe({
+      next: () => {
+        this.saving.set(null);
+        this.toastService.success('Extra reactivado');
+        this.customExtraService.refreshExtras();
+      },
+      error: () => {
+        this.toastService.error('Error al reactivar extra');
+        this.saving.set(null);
+      },
+    });
+  }
+
+  async permanentDeleteExtra(extra: CustomExtra): Promise<void> {
+    const confirmed = await this.confirmDialogService.confirm({
+      title: 'Eliminar extra permanentemente',
+      message: `Esta acción es irreversible. Escriba el nombre del extra para confirmar:`,
+      confirmText: 'Eliminar',
+      requireInput: extra.name,
+    });
+    if (!confirmed) return;
+    this.saving.set(extra.id);
+    this.customExtraService.deleteExtra(extra.id, true).subscribe({
+      next: () => {
+        this.saving.set(null);
+        this.toastService.success('Extra eliminado permanentemente');
+        this.customExtraService.refreshExtras();
+      },
+      error: () => {
+        this.toastService.error('Error al eliminar extra');
+        this.saving.set(null);
+      },
+    });
+  }
+
+  hasUnsavedChanges(): boolean {
+    const id = this.expandedExtraId();
+    if (id === null) return false;
+    return this.hasDraftChanges(id);
+  }
+
+  discardChanges(): void {
+    const id = this.expandedExtraId();
+    if (id !== null) {
+      this.resetDraft(id);
+      this.expandedExtraId.set(null);
+    }
+  }
+
+  async onCollapseToggle(event: Event, extraId: number | 'new'): Promise<void> {
+    event.preventDefault();
+    const current = this.expandedExtraId();
+    const isExpanded = current === extraId;
+
+    if (isExpanded) {
+      if (extraId !== 'new' && this.hasDraftChanges(extraId)) {
+        const confirmed = await this.confirmDialogService.confirm({
+          message: 'Hay cambios sin guardar. ¿Desea descartarlos?',
+        });
+        if (!confirmed) return;
+        this.resetDraft(extraId);
+      }
+      this.expandedExtraId.set(null);
+    } else {
+      if (current !== null && this.hasDraftChanges(current)) {
+        const confirmed = await this.confirmDialogService.confirm({
+          message: 'Hay cambios sin guardar en otro extra. ¿Desea descartarlos?',
+        });
+        if (!confirmed) return;
+        this.resetDraft(current);
+      }
+      this.expandedExtraId.set(extraId);
+    }
+  }
+
+  hasDraftChanges(extraId: number | 'new'): boolean {
+    if (extraId === 'new') return !!this.newExtra.name.trim() || !!this.newExtra.defaultPriceInput.trim();
+    const original = (this.extrasSignal() ?? []).find((e) => e.id === extraId);
+    const draft = this.drafts[extraId];
+    if (!original || !draft) return false;
+    return (
+      draft.name !== original.name ||
+      this.parsePrice(draft.defaultPrice) !== this.toNumberOrNull(original.defaultPrice)
+    );
+  }
+
+  isValidDraftPrice(value: string | undefined | null): boolean {
+    return this.parsePrice(value ?? '') !== null;
+  }
+
+  resetDraft(extraId: number | 'new'): void {
+    if (extraId === 'new') { this.newExtra = this.emptyExtra(); return; }
+    const original = (this.extrasSignal() ?? []).find((e) => e.id === extraId);
+    if (original) this.drafts[extraId] = this.toDraft(original);
+  }
+
+  formatPrice(extra: CustomExtra): string {
+    return `$${(+extra.defaultPrice).toFixed(2)}`;
+  }
+
+  private parsePrice(value: string): number | null {
+    const num = this.toNumberOrNull(value);
+    return num !== null && num > 0 ? num : null;
+  }
+
+  private toNumberOrNull(value: unknown): number | null {
+    if (value == null || value === '') return null;
+    const num = Number(value);
+    return isNaN(num) ? null : num;
+  }
+
+  private toDraft(extra: CustomExtra): CustomExtraDraft {
+    return {
+      name: extra.name,
+      defaultPrice: String(extra.defaultPrice),
+    };
+  }
+
+  private emptyExtra(): { name: string; defaultPriceInput: string } {
+    return { name: '', defaultPriceInput: '' };
+  }
+}

--- a/frontend/src/pages/settings/components/location-manager/location-manager.html
+++ b/frontend/src/pages/settings/components/location-manager/location-manager.html
@@ -1,0 +1,212 @@
+@if (loading()) {
+  <div class="flex justify-center py-12">
+    <span class="loading loading-spinner loading-lg"></span>
+  </div>
+} @else if (error() && activeLocations().length === 0 && inactiveLocations().length === 0) {
+  <div class="alert alert-error alert-soft mt-4" role="alert">
+    <app-icon name="x-circle" />
+    <span>No se pudieron cargar las ubicaciones. Verifica tu conexión e intenta de nuevo.</span>
+    <button class="btn btn-sm btn-ghost" (click)="refresh()">Reintentar</button>
+  </div>
+} @else {
+  <div class="flex items-center justify-between mb-3">
+    <span class="text-sm text-base-content/50" aria-live="polite">
+      @if (revalidating()) { Actualizando... }
+    </span>
+    <button
+      class="btn btn-soft btn-sm gap-1"
+      aria-label="Actualizar lista"
+      [disabled]="loading() || revalidating()"
+      (click)="refresh()"
+    >
+      @if (revalidating()) {
+        <span class="loading loading-spinner loading-xs"></span>
+      } @else {
+        <app-icon name="arrow-path" sizeClass="size-4" />
+      }
+      Actualizar
+    </button>
+  </div>
+
+  <!-- Active locations (drag-drop reorder) -->
+  <div cdkDropList (cdkDropListDropped)="onDrop($event)" data-testid="locations-list">
+    @for (location of activeLocations(); track location.id) {
+      <div
+        cdkDrag
+        [cdkDragDisabled]="reordering() || saving() !== null || expandedLocationId() !== null"
+        class="collapse collapse-arrow bg-base-100 shadow-sm mb-2"
+        data-testid="location-item"
+      >
+        <div *cdkDragPlaceholder class="bg-base-200 rounded-box mb-2" [style.height.px]="dragHeight()"></div>
+        <input type="checkbox" [checked]="expandedLocationId() === location.id" (click)="onCollapseToggle($event, location.id)" />
+        <div class="collapse-title font-medium flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 overflow-hidden" data-testid="location-item-name">
+          <div class="flex items-center gap-2 min-w-0">
+            <div cdkDragHandle class="relative z-10 cursor-grab active:cursor-grabbing touch-none p-1 -ml-1" (pointerdown)="onDragHandleDown($event)">
+              <app-icon name="drag-handle" sizeClass="size-5 opacity-40" />
+            </div>
+            <span class="truncate">{{ location.name }}</span>
+          </div>
+          <div class="flex items-center gap-2 shrink-0">
+            @if (hasDraftChanges(location.id)) {
+              <span class="badge badge-warning badge-sm">Sin guardar</span>
+            }
+            <span class="badge badge-sm" [class.badge-primary]="location.type === 'table'" [class.badge-secondary]="location.type === 'bar'">
+              {{ typeLabels[location.type] }}
+            </span>
+          </div>
+        </div>
+        <div class="collapse-content">
+          <div class="flex flex-col gap-3">
+            <label class="input w-full">
+              <span class="label w-28 shrink-0">Nombre *</span>
+              <input type="text" [(ngModel)]="drafts[location.id].name" />
+            </label>
+            <label class="select w-full">
+              <span class="label w-28 shrink-0">Tipo</span>
+              <select [(ngModel)]="drafts[location.id].type">
+                <option value="table">Mesa</option>
+                <option value="bar">Barra</option>
+              </select>
+            </label>
+            <div class="divider my-1"></div>
+            <div class="flex gap-2">
+              <button
+                class="btn btn-soft btn-success"
+                title="Guardar"
+                [disabled]="!drafts[location.id]?.name?.trim() || !hasDraftChanges(location.id) || saving() === location.id"
+                (click)="saveLocation(location)"
+              >
+                @if (saving() === location.id) {
+                  <span class="loading loading-spinner loading-sm"></span>
+                } @else {
+                  <app-icon name="check-circle" />
+                }
+              </button>
+              <button
+                class="btn btn-soft btn-warning"
+                title="Descartar cambios"
+                [disabled]="!hasDraftChanges(location.id) || saving() === location.id"
+                (click)="resetDraft(location.id)"
+              >
+                <app-icon name="x-circle" />
+              </button>
+              <button
+                class="btn btn-soft btn-error"
+                title="Desactivar"
+                [disabled]="saving() === location.id"
+                (click)="deactivateLocation(location)"
+              >
+                <app-icon name="archive-down" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    }
+  </div>
+
+  @if (activeLocations().length === 0 && inactiveLocations().length === 0) {
+    <p class="text-base-content/60 text-center py-8">No hay ubicaciones registradas.</p>
+  }
+
+  <!-- New location -->
+  <div class="collapse collapse-arrow bg-base-100 shadow-sm mb-2" data-testid="new-location-panel">
+    <input type="checkbox" data-testid="new-location-toggle" [checked]="expandedLocationId() === 'new'" (click)="onCollapseToggle($event, 'new')" />
+    <div class="collapse-title font-medium">
+      <span class="flex items-center gap-2">
+        <app-icon name="plus-circle" sizeClass="size-5 opacity-40" />
+        Nueva ubicación
+      </span>
+    </div>
+    <div class="collapse-content">
+      <div class="flex flex-col gap-3">
+        <label class="input w-full">
+          <span class="label w-28 shrink-0">Nombre *</span>
+          <input type="text" data-testid="new-location-name" [(ngModel)]="newLocation.name" autocomplete="off" />
+        </label>
+        <label class="select w-full">
+          <span class="label w-28 shrink-0">Tipo</span>
+          <select data-testid="new-location-type" [(ngModel)]="newLocation.type">
+            <option value="table">Mesa</option>
+            <option value="bar">Barra</option>
+          </select>
+        </label>
+        <div class="divider my-1"></div>
+        <div class="flex gap-2">
+          <button
+            class="btn btn-soft btn-success"
+            title="Crear"
+            data-testid="new-location-submit"
+            [disabled]="!newLocation.name.trim() || saving() === 'new'"
+            (click)="createLocation()"
+          >
+            @if (saving() === 'new') {
+              <span class="loading loading-spinner loading-sm"></span>
+            } @else {
+              <app-icon name="plus-circle" />
+            }
+          </button>
+          <button
+            class="btn btn-soft btn-warning"
+            title="Descartar"
+            [disabled]="!newLocation.name.trim() || saving() === 'new'"
+            (click)="resetDraft('new')"
+          >
+            <app-icon name="x-circle" />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Inactive locations -->
+  @if (inactiveLocations().length > 0) {
+    <div class="collapse collapse-arrow bg-base-100 mt-4">
+      <input type="checkbox" (change)="expandedInactiveId.set(null)" />
+      <div class="collapse-title text-sm font-medium flex items-center justify-between">
+        Ubicaciones desactivadas
+        <span class="badge badge-sm badge-primary">{{ inactiveLocations().length }}</span>
+      </div>
+      <div class="collapse-content">
+        <div class="join join-vertical w-full">
+          @for (location of inactiveLocations(); track location.id) {
+            <div class="collapse collapse-arrow join-item border-base-300 border bg-base-100">
+              <input type="checkbox" [checked]="expandedInactiveId() === location.id" (click)="expandedInactiveId.set(expandedInactiveId() === location.id ? null : location.id)" />
+              <div class="collapse-title font-semibold flex items-center justify-between gap-1 overflow-hidden">
+                <span class="truncate">{{ location.name }}</span>
+                <span class="badge badge-sm" [class.badge-primary]="location.type === 'table'" [class.badge-secondary]="location.type === 'bar'">
+                  {{ typeLabels[location.type] }}
+                </span>
+              </div>
+              <div class="collapse-content">
+                <div class="flex gap-2">
+                  <button
+                    class="btn btn-soft btn-error"
+                    title="Eliminar permanentemente"
+                    [disabled]="saving() === location.id"
+                    (click)="permanentDeleteLocation(location)"
+                  >
+                    <app-icon name="trash" />
+                  </button>
+                  <button
+                    class="btn btn-soft btn-success"
+                    title="Reactivar"
+                    [disabled]="saving() === location.id"
+                    (click)="reactivateLocation(location)"
+                  >
+                    @if (saving() === location.id) {
+                      <span class="loading loading-spinner loading-sm"></span>
+                    } @else {
+                      <app-icon name="upload" />
+                    }
+                  </button>
+                </div>
+              </div>
+            </div>
+          }
+        </div>
+      </div>
+    </div>
+  }
+
+}

--- a/frontend/src/pages/settings/components/location-manager/location-manager.spec.ts
+++ b/frontend/src/pages/settings/components/location-manager/location-manager.spec.ts
@@ -1,0 +1,334 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { Subject } from 'rxjs';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CdkDragDrop } from '@angular/cdk/drag-drop';
+import { LocationManagerComponent } from './location-manager';
+import { LocationService } from '../../../../core/services/location.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
+import type { Location } from '../../../../core/models';
+
+const LOC_1: Location = {
+  id: 1,
+  name: 'Mesa 1',
+  type: 'table',
+  active: true,
+  displayOrder: 0,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: null,
+};
+
+const LOC_2: Location = {
+  id: 2,
+  name: 'Mesa 2',
+  type: 'table',
+  active: true,
+  displayOrder: 1,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: null,
+};
+
+function makeDrop(previousIndex: number, currentIndex: number): CdkDragDrop<Location[]> {
+  return {
+    previousIndex,
+    currentIndex,
+    item: {} as any,
+    container: {} as any,
+    previousContainer: {} as any,
+    isPointerOverContainer: true,
+    distance: { x: 0, y: 0 },
+    dropPoint: { x: 0, y: 0 },
+    event: {} as any,
+  };
+}
+
+describe('LocationManagerComponent', () => {
+  let fixture: ComponentFixture<LocationManagerComponent>;
+  let component: LocationManagerComponent;
+
+  let locationsData: ReturnType<typeof signal<Location[] | null>>;
+
+  let createLocationSubject: Subject<Location>;
+  let updateLocationSubject: Subject<Location>;
+  let deleteLocationSubject: Subject<void>;
+  let reorderSubject: Subject<void>;
+
+  let locationServiceMock: any;
+  let toastServiceMock: { success: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+  let confirmDialogServiceMock: { confirm: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    locationsData = signal<Location[] | null>(null);
+    createLocationSubject = new Subject();
+    updateLocationSubject = new Subject();
+    deleteLocationSubject = new Subject();
+    reorderSubject = new Subject();
+
+    locationServiceMock = {
+      locations: locationsData.asReadonly(),
+      locationsLoading: signal(false).asReadonly(),
+      locationsRevalidating: signal(false).asReadonly(),
+      locationsError: signal<unknown>(null).asReadonly(),
+      ensureLocations: vi.fn(),
+      refreshLocations: vi.fn(),
+      setLocationsData: vi.fn(),
+      createLocation: vi.fn().mockReturnValue(createLocationSubject.asObservable()),
+      updateLocation: vi.fn().mockReturnValue(updateLocationSubject.asObservable()),
+      deleteLocation: vi.fn().mockReturnValue(deleteLocationSubject.asObservable()),
+      reorderLocations: vi.fn().mockReturnValue(reorderSubject.asObservable()),
+    };
+
+    toastServiceMock = { success: vi.fn(), error: vi.fn() };
+    confirmDialogServiceMock = { confirm: vi.fn().mockResolvedValue(true) };
+
+    await TestBed.configureTestingModule({
+      imports: [LocationManagerComponent],
+      providers: [
+        { provide: LocationService, useValue: locationServiceMock },
+        { provide: ToastService, useValue: toastServiceMock },
+        { provide: ConfirmDialogService, useValue: confirmDialogServiceMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LocationManagerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  // ─── Lifecycle ────────────────────────────────────────────────────────────
+
+  describe('ngOnInit', () => {
+    it('calls ensureLocations()', () => {
+      expect(locationServiceMock.ensureLocations).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── typeLabels ───────────────────────────────────────────────────────────
+
+  describe('typeLabels', () => {
+    it('maps "table" to "Mesa"', () => {
+      expect(component.typeLabels['table']).toBe('Mesa');
+    });
+
+    it('maps "bar" to "Barra"', () => {
+      expect(component.typeLabels['bar']).toBe('Barra');
+    });
+  });
+
+  // ─── hasDraftChanges ─────────────────────────────────────────────────────
+
+  describe('hasDraftChanges()', () => {
+    describe('for "new" location', () => {
+      it('returns false when name is empty', () => {
+        component.newLocation = { name: '', type: 'table' };
+        expect(component.hasDraftChanges('new')).toBe(false);
+      });
+
+      it('returns true when name is non-empty', () => {
+        component.newLocation = { name: 'Mesa 3', type: 'table' };
+        expect(component.hasDraftChanges('new')).toBe(true);
+      });
+
+      it('returns false for whitespace-only name', () => {
+        component.newLocation = { name: '   ', type: 'table' };
+        expect(component.hasDraftChanges('new')).toBe(false);
+      });
+    });
+
+    describe('for existing location', () => {
+      beforeEach(() => {
+        locationsData.set([LOC_1]);
+        TestBed.flushEffects();
+      });
+
+      it('returns false when draft matches original', () => {
+        expect(component.hasDraftChanges(LOC_1.id)).toBe(false);
+      });
+
+      it('returns true when name has changed', () => {
+        component.drafts[LOC_1.id].name = 'Mesa Modificada';
+        expect(component.hasDraftChanges(LOC_1.id)).toBe(true);
+      });
+
+      it('returns true when type has changed', () => {
+        component.drafts[LOC_1.id].type = 'bar';
+        expect(component.hasDraftChanges(LOC_1.id)).toBe(true);
+      });
+
+      it('returns false for unknown id (no original or draft)', () => {
+        expect(component.hasDraftChanges(999)).toBe(false);
+      });
+    });
+  });
+
+  // ─── createLocation ───────────────────────────────────────────────────────
+
+  describe('createLocation()', () => {
+    it('is a no-op when name is empty', () => {
+      component.newLocation = { name: '', type: 'table' };
+      component.createLocation();
+      expect(locationServiceMock.createLocation).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when name is whitespace-only', () => {
+      component.newLocation = { name: '   ', type: 'table' };
+      component.createLocation();
+      expect(locationServiceMock.createLocation).not.toHaveBeenCalled();
+    });
+
+    it('calls createLocation with trimmed name and correct type', () => {
+      component.newLocation = { name: '  Mesa 3  ', type: 'bar' };
+      component.createLocation();
+      expect(locationServiceMock.createLocation).toHaveBeenCalledWith({ name: 'Mesa 3', type: 'bar' });
+    });
+
+    it('defaults to type "table"', () => {
+      component.newLocation = { name: 'Mesa 3', type: 'table' };
+      component.createLocation();
+      expect(locationServiceMock.createLocation).toHaveBeenCalledWith({ name: 'Mesa 3', type: 'table' });
+    });
+
+    it('sets saving to "new" while in-flight', () => {
+      component.newLocation = { name: 'Mesa 3', type: 'table' };
+      component.createLocation();
+      expect(component.saving()).toBe('new');
+    });
+
+    it('resets form and calls refreshLocations on success', () => {
+      component.newLocation = { name: 'Mesa 3', type: 'table' };
+      component.createLocation();
+
+      createLocationSubject.next({ ...LOC_1, name: 'Mesa 3' });
+      createLocationSubject.complete();
+
+      expect(component.saving()).toBeNull();
+      expect(component.newLocation.name).toBe('');
+      expect(component.newLocation.type).toBe('table');
+      expect(locationServiceMock.refreshLocations).toHaveBeenCalledTimes(1);
+      expect(toastServiceMock.success).toHaveBeenCalledWith('Ubicación creada');
+    });
+
+    it('resets saving and shows error toast on failure', () => {
+      component.newLocation = { name: 'Mesa 3', type: 'table' };
+      component.createLocation();
+
+      createLocationSubject.error(new Error('Server error'));
+
+      expect(component.saving()).toBeNull();
+      expect(toastServiceMock.error).toHaveBeenCalledWith('Error al crear ubicación');
+    });
+  });
+
+  // ─── onDrop ───────────────────────────────────────────────────────────────
+
+  describe('onDrop()', () => {
+    beforeEach(() => {
+      locationsData.set([LOC_1, LOC_2]);
+      TestBed.flushEffects();
+    });
+
+    it('does nothing when previousIndex equals currentIndex', () => {
+      component.onDrop(makeDrop(0, 0));
+
+      expect(locationServiceMock.setLocationsData).not.toHaveBeenCalled();
+      expect(locationServiceMock.reorderLocations).not.toHaveBeenCalled();
+    });
+
+    it('calls setLocationsData with optimistically reordered list', () => {
+      component.onDrop(makeDrop(0, 1));
+
+      expect(locationServiceMock.setLocationsData).toHaveBeenCalledTimes(1);
+      const updatedLocations: Location[] = locationServiceMock.setLocationsData.mock.calls[0][0];
+      expect(updatedLocations[0].id).toBe(LOC_2.id);
+      expect(updatedLocations[1].id).toBe(LOC_1.id);
+    });
+
+    it('calls reorderLocations with the new ID order', () => {
+      component.onDrop(makeDrop(0, 1));
+
+      expect(locationServiceMock.reorderLocations).toHaveBeenCalledWith([LOC_2.id, LOC_1.id]);
+    });
+
+    it('sets reordering to true while request is in-flight', () => {
+      component.onDrop(makeDrop(0, 1));
+      expect(component.reordering()).toBe(true);
+    });
+
+    it('clears reordering on success', () => {
+      component.onDrop(makeDrop(0, 1));
+      reorderSubject.next();
+      reorderSubject.complete();
+      expect(component.reordering()).toBe(false);
+    });
+
+    it('refreshes locations and clears reordering on error', () => {
+      component.onDrop(makeDrop(0, 1));
+      reorderSubject.error(new Error('Reorder failed'));
+
+      expect(component.reordering()).toBe(false);
+      expect(locationServiceMock.refreshLocations).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── hasUnsavedChanges / discardChanges ───────────────────────────────────
+
+  describe('hasUnsavedChanges()', () => {
+    it('returns false when no location is expanded', () => {
+      component.expandedLocationId.set(null);
+      expect(component.hasUnsavedChanges()).toBe(false);
+    });
+
+    it('returns true when expanded location has unsaved changes', () => {
+      locationsData.set([LOC_1]);
+      TestBed.flushEffects();
+      component.expandedLocationId.set(LOC_1.id);
+      component.drafts[LOC_1.id].name = 'Changed';
+
+      expect(component.hasUnsavedChanges()).toBe(true);
+    });
+  });
+
+  describe('discardChanges()', () => {
+    it('resets the draft to original values and clears expandedLocationId', () => {
+      locationsData.set([LOC_1]);
+      TestBed.flushEffects();
+      component.expandedLocationId.set(LOC_1.id);
+      component.drafts[LOC_1.id].name = 'Changed';
+
+      component.discardChanges();
+
+      expect(component.drafts[LOC_1.id].name).toBe(LOC_1.name);
+      expect(component.expandedLocationId()).toBeNull();
+    });
+
+    it('does nothing when no location is expanded', () => {
+      component.expandedLocationId.set(null);
+      component.discardChanges();
+      expect(component.expandedLocationId()).toBeNull();
+    });
+  });
+
+  // ─── computed signals ─────────────────────────────────────────────────────
+
+  describe('activeLocations / inactiveLocations computed', () => {
+    it('separates active from inactive locations', () => {
+      const inactive: Location = { ...LOC_1, id: 3, active: false, displayOrder: 2 };
+      locationsData.set([LOC_1, LOC_2, inactive]);
+      TestBed.flushEffects();
+
+      expect(component.activeLocations()).toHaveLength(2);
+      expect(component.inactiveLocations()).toHaveLength(1);
+    });
+
+    it('sorts active locations by displayOrder ascending', () => {
+      const high: Location = { ...LOC_1, id: 3, displayOrder: 10 };
+      locationsData.set([high, LOC_2, LOC_1]);
+      TestBed.flushEffects();
+
+      expect(component.activeLocations()[0].displayOrder).toBe(0);
+      expect(component.activeLocations()[1].displayOrder).toBe(1);
+      expect(component.activeLocations()[2].displayOrder).toBe(10);
+    });
+  });
+});

--- a/frontend/src/pages/settings/components/location-manager/location-manager.ts
+++ b/frontend/src/pages/settings/components/location-manager/location-manager.ts
@@ -1,0 +1,268 @@
+import { Component, computed, effect, inject, OnInit, signal, untracked } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import {
+  CdkDropList,
+  CdkDrag,
+  CdkDragHandle,
+  CdkDragPlaceholder,
+  moveItemInArray,
+  type CdkDragDrop,
+} from '@angular/cdk/drag-drop';
+import { LocationService } from '../../../../core/services/location.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
+import { IconComponent } from '../../../../shared/components/icon';
+import type {
+  Location,
+  LocationDraft,
+  CreateLocationPayload,
+} from '../../../../core/models';
+
+@Component({
+  selector: 'app-location-manager',
+  imports: [FormsModule, CdkDropList, CdkDrag, CdkDragHandle, CdkDragPlaceholder, IconComponent],
+  templateUrl: './location-manager.html',
+  styleUrl: '../../../../shared/styles/manager.css',
+})
+export class LocationManagerComponent implements OnInit {
+  private readonly locationService = inject(LocationService);
+  private readonly toastService = inject(ToastService);
+  private readonly confirmDialogService = inject(ConfirmDialogService);
+
+  readonly loading = this.locationService.locationsLoading;
+  readonly revalidating = this.locationService.locationsRevalidating;
+  readonly error = this.locationService.locationsError;
+  private readonly locationsSignal = this.locationService.locations;
+
+  saving = signal<number | 'new' | null>(null);
+  reordering = signal(false);
+  dragHeight = signal(0);
+  expandedLocationId = signal<number | 'new' | null>(null);
+  expandedInactiveId = signal<number | null>(null);
+
+  activeLocations = computed(() =>
+    (this.locationsSignal() ?? [])
+      .filter((l) => l.active)
+      .sort((a, b) => a.displayOrder - b.displayOrder)
+  );
+
+  inactiveLocations = computed(() =>
+    (this.locationsSignal() ?? [])
+      .filter((l) => !l.active)
+      .sort((a, b) => a.displayOrder - b.displayOrder)
+  );
+
+  drafts: Record<number, LocationDraft> = {};
+  newLocation: CreateLocationPayload = this.emptyLocation();
+
+  readonly typeLabels: Record<string, string> = { table: 'Mesa', bar: 'Barra' };
+
+  constructor() {
+    effect(() => {
+      const items = this.locationsSignal();
+      if (!items) return;
+      untracked(() => {
+        const ids = new Set(items.map((l) => l.id));
+        for (const item of items) {
+          if (!this.drafts[item.id] || !this.hasDraftChanges(item.id)) {
+            this.drafts[item.id] = this.toDraft(item);
+          }
+        }
+        for (const id of Object.keys(this.drafts)) {
+          if (!ids.has(Number(id))) delete this.drafts[Number(id)];
+        }
+      });
+    });
+  }
+
+  ngOnInit(): void {
+    this.locationService.ensureLocations();
+  }
+
+  refresh(): void {
+    this.locationService.refreshLocations();
+  }
+
+  createLocation(): void {
+    if (!this.newLocation.name.trim()) return;
+    this.saving.set('new');
+    const payload: CreateLocationPayload = {
+      name: this.newLocation.name.trim(),
+      type: this.newLocation.type,
+    };
+    this.locationService.createLocation(payload).subscribe({
+      next: () => {
+        this.newLocation = this.emptyLocation();
+        this.saving.set(null);
+        this.toastService.success('Ubicación creada');
+        this.locationService.refreshLocations();
+      },
+      error: () => {
+        this.toastService.error('Error al crear ubicación');
+        this.saving.set(null);
+      },
+    });
+  }
+
+  saveLocation(location: Location): void {
+    const draft = this.drafts[location.id];
+    if (!draft) return;
+    this.saving.set(location.id);
+    this.locationService.updateLocation(location.id, { name: draft.name, type: draft.type }).subscribe({
+      next: () => {
+        this.saving.set(null);
+        this.toastService.success('Ubicación actualizada');
+        this.locationService.refreshLocations();
+      },
+      error: () => {
+        this.toastService.error('Error al actualizar ubicación');
+        this.saving.set(null);
+      },
+    });
+  }
+
+  async deactivateLocation(location: Location): Promise<void> {
+    const confirmed = await this.confirmDialogService.confirm({
+      title: 'Desactivar ubicación',
+      message: `Se desactivará "${location.name}". ¿Desea continuar?`,
+      confirmText: 'Desactivar',
+    });
+    if (!confirmed) return;
+    this.saving.set(location.id);
+    this.locationService.deleteLocation(location.id).subscribe({
+      next: () => {
+        this.saving.set(null);
+        this.toastService.success('Ubicación desactivada');
+        this.locationService.refreshLocations();
+      },
+      error: () => {
+        this.toastService.error('Error al desactivar ubicación');
+        this.saving.set(null);
+      },
+    });
+  }
+
+  reactivateLocation(location: Location): void {
+    this.saving.set(location.id);
+    this.locationService.updateLocation(location.id, { active: true }).subscribe({
+      next: () => {
+        this.saving.set(null);
+        this.toastService.success('Ubicación reactivada');
+        this.locationService.refreshLocations();
+      },
+      error: () => {
+        this.toastService.error('Error al reactivar ubicación');
+        this.saving.set(null);
+      },
+    });
+  }
+
+  async permanentDeleteLocation(location: Location): Promise<void> {
+    const confirmed = await this.confirmDialogService.confirm({
+      title: 'Eliminar ubicación permanentemente',
+      message: `Esta acción es irreversible. Escriba el nombre de la ubicación para confirmar:`,
+      confirmText: 'Eliminar',
+      requireInput: location.name,
+    });
+    if (!confirmed) return;
+    this.saving.set(location.id);
+    this.locationService.deleteLocation(location.id, true).subscribe({
+      next: () => {
+        this.saving.set(null);
+        this.toastService.success('Ubicación eliminada permanentemente');
+        this.locationService.refreshLocations();
+      },
+      error: () => {
+        this.toastService.error('Error al eliminar ubicación');
+        this.saving.set(null);
+      },
+    });
+  }
+
+  onDragHandleDown(event: PointerEvent): void {
+    const row = (event.target as HTMLElement).closest('[cdkDrag]');
+    if (row) this.dragHeight.set(row.getBoundingClientRect().height);
+  }
+
+  onDrop(event: CdkDragDrop<Location[]>): void {
+    if (event.previousIndex === event.currentIndex) return;
+    const items = [...this.activeLocations()];
+    moveItemInArray(items, event.previousIndex, event.currentIndex);
+    const updated = items.map((loc, index) => ({ ...loc, displayOrder: index }));
+    this.locationService.setLocationsData([...updated, ...this.inactiveLocations()]);
+    this.reordering.set(true);
+    this.locationService.reorderLocations(items.map((l) => l.id)).subscribe({
+      next: () => {
+        this.reordering.set(false);
+        this.toastService.success('Orden actualizado');
+      },
+      error: () => {
+        this.reordering.set(false);
+        this.toastService.error('Error al actualizar orden');
+        this.locationService.refreshLocations();
+      },
+    });
+  }
+
+  hasUnsavedChanges(): boolean {
+    const id = this.expandedLocationId();
+    if (id === null) return false;
+    return this.hasDraftChanges(id);
+  }
+
+  discardChanges(): void {
+    const id = this.expandedLocationId();
+    if (id !== null) {
+      this.resetDraft(id);
+      this.expandedLocationId.set(null);
+    }
+  }
+
+  async onCollapseToggle(event: Event, locationId: number | 'new'): Promise<void> {
+    event.preventDefault();
+    const current = this.expandedLocationId();
+    const isExpanded = current === locationId;
+
+    if (isExpanded) {
+      if (locationId !== 'new' && this.hasDraftChanges(locationId)) {
+        const confirmed = await this.confirmDialogService.confirm({
+          message: 'Hay cambios sin guardar. ¿Desea descartarlos?',
+        });
+        if (!confirmed) return;
+        this.resetDraft(locationId);
+      }
+      this.expandedLocationId.set(null);
+    } else {
+      if (current !== null && this.hasDraftChanges(current)) {
+        const confirmed = await this.confirmDialogService.confirm({
+          message: 'Hay cambios sin guardar en otra ubicación. ¿Desea descartarlos?',
+        });
+        if (!confirmed) return;
+        this.resetDraft(current);
+      }
+      this.expandedLocationId.set(locationId);
+    }
+  }
+
+  hasDraftChanges(locationId: number | 'new'): boolean {
+    if (locationId === 'new') return !!this.newLocation.name.trim();
+    const original = (this.locationsSignal() ?? []).find((l) => l.id === locationId);
+    const draft = this.drafts[locationId];
+    if (!original || !draft) return false;
+    return draft.name !== original.name || draft.type !== original.type;
+  }
+
+  resetDraft(locationId: number | 'new'): void {
+    if (locationId === 'new') { this.newLocation = this.emptyLocation(); return; }
+    const original = (this.locationsSignal() ?? []).find((l) => l.id === locationId);
+    if (original) this.drafts[locationId] = this.toDraft(original);
+  }
+
+  private toDraft(location: Location): LocationDraft {
+    return { name: location.name, type: location.type };
+  }
+
+  private emptyLocation(): CreateLocationPayload {
+    return { name: '', type: 'table' };
+  }
+}

--- a/frontend/src/pages/settings/components/product-manager/product-manager.html
+++ b/frontend/src/pages/settings/components/product-manager/product-manager.html
@@ -145,7 +145,7 @@
                         class="btn btn-soft btn-success"
                         title="Guardar"
                         aria-label="Guardar producto"
-                        [disabled]="!drafts[product.id]?.name?.trim() || !hasDraftChanges(product.id) || saving() === product.id"
+                        [disabled]="!drafts[product.id]?.name?.trim() || !isValidDraftPrice(drafts[product.id]?.price) || !hasDraftChanges(product.id) || saving() === product.id"
                         (click)="saveProduct(product)"
                       >
                         @if (saving() === product.id) {
@@ -258,7 +258,7 @@
               class="btn btn-soft btn-success"
               title="Crear"
               aria-label="Crear producto"
-              [disabled]="!newProduct.name.trim() || !newProduct.categoryId || saving() === 'new'"
+              [disabled]="!newProduct.name.trim() || !newProduct.categoryId || !isValidDraftPrice(newProduct.price) || saving() === 'new'"
               (click)="createProduct()"
             >
               @if (saving() === 'new') {

--- a/frontend/src/pages/settings/components/product-manager/product-manager.ts
+++ b/frontend/src/pages/settings/components/product-manager/product-manager.ts
@@ -106,6 +106,7 @@ export class ProductManagerComponent implements OnInit {
 
   createProduct(): void {
     if (!this.newProduct.name.trim() || !this.newProduct.categoryId) return;
+    if (!this.isValidDraftPrice(this.newProduct.price)) return;
 
     const inactive = this.inactiveProducts().find(
       (p) => p.name.toLowerCase() === this.newProduct.name.trim().toLowerCase()
@@ -159,6 +160,7 @@ export class ProductManagerComponent implements OnInit {
   saveProduct(product: Product): void {
     const draft = this.drafts[product.id];
     if (!draft) return;
+    if (!this.isValidDraftPrice(draft.price)) return;
 
     this.saving.set(product.id);
     const payload: UpdateProductPayload = {
@@ -374,6 +376,11 @@ export class ProductManagerComponent implements OnInit {
       !!this.newProduct.image?.trim() ||
       !!this.newProduct.customizable
     );
+  }
+
+  isValidDraftPrice(value: unknown): boolean {
+    const price = this.toNumberOrNull(value);
+    return price === null || price >= 0;
   }
 
   resetNewProduct(): void {

--- a/frontend/src/pages/settings/settings.html
+++ b/frontend/src/pages/settings/settings.html
@@ -73,6 +73,36 @@
           </div>
         }
       </div>
+
+      <input
+        type="radio"
+        name="settings_tabs"
+        class="tab"
+        aria-label="Ubicaciones"
+        [checked]="activeTab() === 'locations'"
+        (click)="selectTab($event, 'locations')" />
+      <div class="tab-content bg-base-200 p-0">
+        @if (activeTab() === 'locations') {
+          <div [class.slide-from-left]="slideDirection() === 'left'" [class.slide-from-right]="slideDirection() === 'right'">
+            <app-location-manager />
+          </div>
+        }
+      </div>
+
+      <input
+        type="radio"
+        name="settings_tabs"
+        class="tab"
+        aria-label="Extras"
+        [checked]="activeTab() === 'extras'"
+        (click)="selectTab($event, 'extras')" />
+      <div class="tab-content bg-base-200 p-0">
+        @if (activeTab() === 'extras') {
+          <div [class.slide-from-left]="slideDirection() === 'left'" [class.slide-from-right]="slideDirection() === 'right'">
+            <app-custom-extra-manager />
+          </div>
+        }
+      </div>
     </div>
   }
 

--- a/frontend/src/pages/settings/settings.ts
+++ b/frontend/src/pages/settings/settings.ts
@@ -3,6 +3,8 @@ import { ThemeSelectorComponent } from './components/theme-selector/theme-select
 import { CategoryManagerComponent } from './components/category-manager/category-manager';
 import { ProductManagerComponent } from './components/product-manager/product-manager';
 import { UserManagerComponent } from './components/user-manager/user-manager';
+import { LocationManagerComponent } from './components/location-manager/location-manager';
+import { CustomExtraManagerComponent } from './components/custom-extra-manager/custom-extra-manager';
 import { IconComponent } from '../../shared/components/icon';
 import { ConfirmDialogService } from '../../core/services/confirm-dialog.service';
 import { SplashService } from '../../core/services/splash.service';
@@ -10,13 +12,13 @@ import { AuthService } from '../../core/services/auth.service';
 import { HasUnsavedChanges } from '../../core/guards/unsaved-changes.guard';
 import { ROLE_LABELS } from '../../core/models';
 
-type SettingsTab = 'categories' | 'products' | 'users';
+type SettingsTab = 'categories' | 'products' | 'users' | 'locations' | 'extras';
 
-const TAB_ORDER: SettingsTab[] = ['categories', 'products', 'users'];
+const TAB_ORDER: SettingsTab[] = ['categories', 'products', 'users', 'locations', 'extras'];
 
 @Component({
   selector: 'app-settings-page',
-  imports: [ThemeSelectorComponent, CategoryManagerComponent, ProductManagerComponent, UserManagerComponent, IconComponent],
+  imports: [ThemeSelectorComponent, CategoryManagerComponent, ProductManagerComponent, UserManagerComponent, LocationManagerComponent, CustomExtraManagerComponent, IconComponent],
   templateUrl: './settings.html',
   styleUrl: './settings.css',
 })
@@ -28,6 +30,8 @@ export class SettingsPage implements HasUnsavedChanges, OnInit {
   categoryManager = viewChild(CategoryManagerComponent);
   productManager = viewChild(ProductManagerComponent);
   userManager = viewChild(UserManagerComponent);
+  locationManager = viewChild(LocationManagerComponent);
+  customExtraManager = viewChild(CustomExtraManagerComponent);
 
   protected readonly roleLabels = ROLE_LABELS;
 
@@ -39,16 +43,21 @@ export class SettingsPage implements HasUnsavedChanges, OnInit {
   }
 
   hasUnsavedChanges(): boolean {
-    const categoryMgr = this.categoryManager();
-    const productMgr = this.productManager();
-    const userMgr = this.userManager();
-    return !!(categoryMgr?.hasUnsavedChanges() || productMgr?.hasUnsavedChanges() || userMgr?.hasUnsavedChanges());
+    return !!(
+      this.categoryManager()?.hasUnsavedChanges() ||
+      this.productManager()?.hasUnsavedChanges() ||
+      this.userManager()?.hasUnsavedChanges() ||
+      this.locationManager()?.hasUnsavedChanges() ||
+      this.customExtraManager()?.hasUnsavedChanges()
+    );
   }
 
   discardChanges(): void {
     this.categoryManager()?.discardChanges();
     this.productManager()?.discardChanges();
     this.userManager()?.discardChanges();
+    this.locationManager()?.discardChanges();
+    this.customExtraManager()?.discardChanges();
   }
 
   async selectTab(event: Event, tab: SettingsTab): Promise<void> {
@@ -72,11 +81,13 @@ export class SettingsPage implements HasUnsavedChanges, OnInit {
     this.activeTab.set(tab);
   }
 
-  private getActiveComponent(): CategoryManagerComponent | ProductManagerComponent | UserManagerComponent | undefined {
+  private getActiveComponent(): CategoryManagerComponent | ProductManagerComponent | UserManagerComponent | LocationManagerComponent | CustomExtraManagerComponent | undefined {
     switch (this.activeTab()) {
       case 'categories': return this.categoryManager();
       case 'products': return this.productManager();
       case 'users': return this.userManager();
+      case 'locations': return this.locationManager();
+      case 'extras': return this.customExtraManager();
     }
   }
 }

--- a/frontend/src/shared/components/toast/toast.ts
+++ b/frontend/src/shared/components/toast/toast.ts
@@ -13,7 +13,7 @@ const ALERT_CLASS: Record<ToastType, string> = {
   template: `
     <div class="toast toast-end toast-bottom z-50">
       @for (toast of toastService.toasts(); track toast.id) {
-        <div [class]="alertClass[toast.type]">
+        <div [class]="alertClass[toast.type]" data-testid="toast" [attr.data-toast-type]="toast.type">
           <span>{{ toast.message }}</span>
         </div>
       }


### PR DESCRIPTION
## Summary
- Add `custom_extras` and `locations` tables via Prisma migrations (+ seed for 7 tables + 1 bar).
- Add backend API: `GET/POST/PUT/DELETE /api/extras` (authenticated) and `GET/POST/PUT/DELETE/PATCH /api/locations` (GET authenticated, mutations admin-only) with Zod validation, soft/hard delete, and atomic reorder.
- Add admin UI (custom-extra-manager, location-manager with drag-and-drop), SWR caching for both tabs, Phase 2 doc + README/CLAUDE.md updates.

## Test plan
- [ ] `npm test` (backend unit) and `npm run test:integration` pass
- [ ] E2E `settings.e2e.ts` passes
- [ ] Manual: create/edit/deactivate/reorder locations and extras from settings UI
- [ ] Manual: verify seed runs cleanly on a fresh DB (`npm run db:reset && npm run prisma:seed`)

Closes #46
Closes #47