### PR TITLE
Fix Deploy Frontend CI: upgrade Vercel CLI to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,7 @@ jobs:
 
       - uses: amondnet/vercel-action@v25
         with:
+          vercel-version: latest
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## Summary
- The `Deploy Frontend` job failed on master because `amondnet/vercel-action@v25` pins `vercel@25.1.0`, which Vercel's deploy endpoint rejects (requires >= 47.2.2).
- Pass `vercel-version: latest` to the action so it installs a current CLI.

Failing run: https://github.com/LeonOmega2712/MEPPOS/actions/runs/24651799088

Closes #55

## Test plan
- [ ] CI passes on this PR (backend + frontend + E2E).
- [ ] After merge to master, `Deploy Frontend` succeeds and the site updates on Vercel.