### PR TITLE
Fix stale settings-manager state after deactivate/delete and horizontal scroll on Ubicaciones/Extras

### DIFF
--- a/frontend/src/pages/settings/components/category-manager/category-manager.spec.ts
+++ b/frontend/src/pages/settings/components/category-manager/category-manager.spec.ts
@@ -1,0 +1,121 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { Subject } from 'rxjs';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CategoryManagerComponent } from './category-manager';
+import { CategoryService } from '../../../../core/services/category.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
+import type { Category } from '../../../../core/models';
+
+const CAT_1: Category = {
+  id: 1,
+  name: 'Mariscos',
+  description: null,
+  basePrice: null,
+  image: null,
+  displayOrder: 0,
+  active: true,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  _count: { products: 0 },
+};
+
+const CAT_2: Category = { ...CAT_1, id: 2, name: 'Bebidas', displayOrder: 1 };
+
+describe('CategoryManagerComponent — issue #51 cleanup', () => {
+  let fixture: ComponentFixture<CategoryManagerComponent>;
+  let component: CategoryManagerComponent;
+
+  let categoriesData: ReturnType<typeof signal<Category[] | null>>;
+  let deleteSubject: Subject<void>;
+  let categoryServiceMock: any;
+  let toastServiceMock: { success: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn>; info: ReturnType<typeof vi.fn> };
+  let confirmDialogServiceMock: { confirm: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    categoriesData = signal<Category[] | null>(null);
+    deleteSubject = new Subject();
+
+    categoryServiceMock = {
+      categories: categoriesData.asReadonly(),
+      categoriesLoading: signal(false).asReadonly(),
+      categoriesRevalidating: signal(false).asReadonly(),
+      categoriesError: signal<unknown>(null).asReadonly(),
+      ensureCategories: vi.fn(),
+      refreshCategories: vi.fn(),
+      setCategoriesData: vi.fn(),
+      createCategory: vi.fn().mockReturnValue(new Subject().asObservable()),
+      updateCategory: vi.fn().mockReturnValue(new Subject().asObservable()),
+      deleteCategory: vi.fn().mockReturnValue(deleteSubject.asObservable()),
+      reorderCategories: vi.fn().mockReturnValue(new Subject().asObservable()),
+    };
+
+    toastServiceMock = { success: vi.fn(), error: vi.fn(), info: vi.fn() };
+    confirmDialogServiceMock = { confirm: vi.fn().mockResolvedValue(true) };
+
+    await TestBed.configureTestingModule({
+      imports: [CategoryManagerComponent],
+      providers: [
+        { provide: CategoryService, useValue: categoryServiceMock },
+        { provide: ToastService, useValue: toastServiceMock },
+        { provide: ConfirmDialogService, useValue: confirmDialogServiceMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CategoryManagerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('deactivateCategory() cleanup', () => {
+    beforeEach(() => {
+      categoriesData.set([CAT_1, CAT_2]);
+      TestBed.flushEffects();
+    });
+
+    it('clears expandedCategoryId and resets draft after success, so opening another row does not trigger the unsaved-changes dialog', async () => {
+      component.expandedCategoryId.set(CAT_1.id);
+      component.drafts[CAT_1.id].name = 'Edited but not saved';
+
+      await component.deactivateCategory(CAT_1);
+      deleteSubject.next();
+      deleteSubject.complete();
+
+      expect(component.expandedCategoryId()).toBeNull();
+      expect(component.hasDraftChanges(CAT_1.id)).toBe(false);
+
+      await component.onCollapseToggle(new Event('click'), CAT_2.id);
+
+      expect(confirmDialogServiceMock.confirm).toHaveBeenCalledTimes(1);
+      expect(component.expandedCategoryId()).toBe(CAT_2.id);
+    });
+
+    it('does NOT clear expanded state on error', async () => {
+      component.expandedCategoryId.set(CAT_1.id);
+      component.drafts[CAT_1.id].name = 'Edited';
+
+      await component.deactivateCategory(CAT_1);
+      deleteSubject.error(new Error('boom'));
+
+      expect(component.expandedCategoryId()).toBe(CAT_1.id);
+      expect(component.hasDraftChanges(CAT_1.id)).toBe(true);
+    });
+  });
+
+  describe('permanentDeleteCategory() cleanup', () => {
+    it('clears expandedInactiveId after success', async () => {
+      const inactive: Category = { ...CAT_1, id: 5, active: false };
+      categoriesData.set([inactive]);
+      TestBed.flushEffects();
+      component.expandedInactiveId.set(inactive.id);
+
+      await component.permanentDeleteCategory(inactive);
+      deleteSubject.next();
+      deleteSubject.complete();
+
+      expect(component.expandedInactiveId()).toBeNull();
+      expect(component.drafts[inactive.id]).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/pages/settings/components/category-manager/category-manager.ts
+++ b/frontend/src/pages/settings/components/category-manager/category-manager.ts
@@ -259,6 +259,7 @@ export class CategoryManagerComponent implements OnInit {
     this.categoryService.deleteCategory(category.id).subscribe({
       next: () => {
         this.saving.set(null);
+        this.clearDraftAndCollapse(category.id);
         this.toastService.success('Categoría desactivada');
         this.categoryService.refreshCategories();
       },
@@ -296,6 +297,7 @@ export class CategoryManagerComponent implements OnInit {
     this.categoryService.deleteCategory(category.id, true).subscribe({
       next: () => {
         this.saving.set(null);
+        this.clearDraftAndCollapse(category.id);
         this.toastService.success('Categoría eliminada permanentemente');
         this.categoryService.refreshCategories();
       },
@@ -322,6 +324,12 @@ export class CategoryManagerComponent implements OnInit {
 
   resetNewCategory(): void {
     this.newCategory = this.emptyCategory();
+  }
+
+  private clearDraftAndCollapse(categoryId: number): void {
+    delete this.drafts[categoryId];
+    if (this.expandedCategoryId() === categoryId) this.expandedCategoryId.set(null);
+    if (this.expandedInactiveId() === categoryId) this.expandedInactiveId.set(null);
   }
 
   private emptyCategory(): CreateCategoryPayload {

--- a/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.html
+++ b/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.html
@@ -9,6 +9,7 @@
     <button class="btn btn-sm btn-ghost" (click)="refresh()">Reintentar</button>
   </div>
 } @else {
+  <div class="overflow-x-hidden">
   <div class="flex items-center justify-between mb-3">
     <span class="text-sm text-base-content/50" aria-live="polite">
       @if (revalidating()) { Actualizando... }
@@ -187,4 +188,5 @@
       </div>
     </div>
   }
+  </div>
 }

--- a/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.spec.ts
+++ b/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.spec.ts
@@ -351,4 +351,57 @@ describe('CustomExtraManagerComponent', () => {
       expect(component.activeExtras()[1].name).toBe('Limón');
     });
   });
+
+  // ─── deactivateExtra cleanup (issue #51) ─────────────────────────────────
+
+  describe('deactivateExtra() cleanup', () => {
+    beforeEach(() => {
+      extrasData.set([EXTRA_1, EXTRA_2]);
+      TestBed.flushEffects();
+    });
+
+    it('clears expandedExtraId and resets draft after success, so opening another row does not trigger the unsaved-changes dialog', async () => {
+      component.expandedExtraId.set(EXTRA_1.id);
+      component.drafts[EXTRA_1.id].name = 'Edited but not saved';
+
+      await component.deactivateExtra(EXTRA_1);
+      deleteExtraSubject.next();
+      deleteExtraSubject.complete();
+
+      expect(component.expandedExtraId()).toBeNull();
+      expect(component.hasDraftChanges(EXTRA_1.id)).toBe(false);
+
+      await component.onCollapseToggle(new Event('click'), EXTRA_2.id);
+
+      expect(confirmDialogServiceMock.confirm).toHaveBeenCalledTimes(1);
+      expect(component.expandedExtraId()).toBe(EXTRA_2.id);
+    });
+
+    it('does NOT clear expanded state on error', async () => {
+      component.expandedExtraId.set(EXTRA_1.id);
+      component.drafts[EXTRA_1.id].name = 'Edited';
+
+      await component.deactivateExtra(EXTRA_1);
+      deleteExtraSubject.error(new Error('boom'));
+
+      expect(component.expandedExtraId()).toBe(EXTRA_1.id);
+      expect(component.hasDraftChanges(EXTRA_1.id)).toBe(true);
+    });
+  });
+
+  describe('permanentDeleteExtra() cleanup', () => {
+    it('clears expandedInactiveId after success', async () => {
+      const inactive: CustomExtra = { ...EXTRA_1, id: 5, active: false };
+      extrasData.set([inactive]);
+      TestBed.flushEffects();
+      component.expandedInactiveId.set(inactive.id);
+
+      await component.permanentDeleteExtra(inactive);
+      deleteExtraSubject.next();
+      deleteExtraSubject.complete();
+
+      expect(component.expandedInactiveId()).toBeNull();
+      expect(component.drafts[inactive.id]).toBeUndefined();
+    });
+  });
 });

--- a/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.ts
+++ b/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.ts
@@ -121,6 +121,7 @@ export class CustomExtraManagerComponent implements OnInit {
     this.customExtraService.deleteExtra(extra.id).subscribe({
       next: () => {
         this.saving.set(null);
+        this.clearDraftAndCollapse(extra.id);
         this.toastService.success('Extra desactivado');
         this.customExtraService.refreshExtras();
       },
@@ -158,6 +159,7 @@ export class CustomExtraManagerComponent implements OnInit {
     this.customExtraService.deleteExtra(extra.id, true).subscribe({
       next: () => {
         this.saving.set(null);
+        this.clearDraftAndCollapse(extra.id);
         this.toastService.success('Extra eliminado permanentemente');
         this.customExtraService.refreshExtras();
       },
@@ -231,6 +233,12 @@ export class CustomExtraManagerComponent implements OnInit {
 
   formatPrice(extra: CustomExtra): string {
     return `$${(+extra.defaultPrice).toFixed(2)}`;
+  }
+
+  private clearDraftAndCollapse(extraId: number): void {
+    delete this.drafts[extraId];
+    if (this.expandedExtraId() === extraId) this.expandedExtraId.set(null);
+    if (this.expandedInactiveId() === extraId) this.expandedInactiveId.set(null);
   }
 
   private parsePrice(value: string): number | null {

--- a/frontend/src/pages/settings/components/location-manager/location-manager.html
+++ b/frontend/src/pages/settings/components/location-manager/location-manager.html
@@ -9,6 +9,7 @@
     <button class="btn btn-sm btn-ghost" (click)="refresh()">Reintentar</button>
   </div>
 } @else {
+  <div class="overflow-x-hidden">
   <div class="flex items-center justify-between mb-3">
     <span class="text-sm text-base-content/50" aria-live="polite">
       @if (revalidating()) { Actualizando... }
@@ -208,5 +209,5 @@
       </div>
     </div>
   }
-
+  </div>
 }

--- a/frontend/src/pages/settings/components/location-manager/location-manager.spec.ts
+++ b/frontend/src/pages/settings/components/location-manager/location-manager.spec.ts
@@ -309,6 +309,60 @@ describe('LocationManagerComponent', () => {
     });
   });
 
+  // ─── deactivateLocation cleanup (issue #51) ──────────────────────────────
+
+  describe('deactivateLocation() cleanup', () => {
+    beforeEach(() => {
+      locationsData.set([LOC_1, LOC_2]);
+      TestBed.flushEffects();
+    });
+
+    it('clears expandedLocationId and resets draft after success, so opening another row does not trigger the unsaved-changes dialog', async () => {
+      component.expandedLocationId.set(LOC_1.id);
+      component.drafts[LOC_1.id].name = 'Edited but not saved';
+
+      await component.deactivateLocation(LOC_1);
+      deleteLocationSubject.next();
+      deleteLocationSubject.complete();
+
+      expect(component.expandedLocationId()).toBeNull();
+      expect(component.hasDraftChanges(LOC_1.id)).toBe(false);
+
+      await component.onCollapseToggle(new Event('click'), LOC_2.id);
+
+      expect(confirmDialogServiceMock.confirm).toHaveBeenCalledTimes(1);
+      expect(component.expandedLocationId()).toBe(LOC_2.id);
+    });
+
+    it('does NOT clear expanded state on error', async () => {
+      component.expandedLocationId.set(LOC_1.id);
+      component.drafts[LOC_1.id].name = 'Edited';
+
+      await component.deactivateLocation(LOC_1);
+      deleteLocationSubject.error(new Error('boom'));
+
+      expect(component.expandedLocationId()).toBe(LOC_1.id);
+      expect(component.hasDraftChanges(LOC_1.id)).toBe(true);
+    });
+  });
+
+  describe('permanentDeleteLocation() cleanup', () => {
+    it('clears expandedInactiveId after success', async () => {
+      const inactive: Location = { ...LOC_1, id: 5, active: false };
+      locationsData.set([inactive]);
+      TestBed.flushEffects();
+      component.expandedInactiveId.set(inactive.id);
+      confirmDialogServiceMock.confirm.mockResolvedValueOnce(true);
+
+      await component.permanentDeleteLocation(inactive);
+      deleteLocationSubject.next();
+      deleteLocationSubject.complete();
+
+      expect(component.expandedInactiveId()).toBeNull();
+      expect(component.drafts[inactive.id]).toBeUndefined();
+    });
+  });
+
   // ─── computed signals ─────────────────────────────────────────────────────
 
   describe('activeLocations / inactiveLocations computed', () => {

--- a/frontend/src/pages/settings/components/location-manager/location-manager.ts
+++ b/frontend/src/pages/settings/components/location-manager/location-manager.ts
@@ -132,6 +132,7 @@ export class LocationManagerComponent implements OnInit {
     this.locationService.deleteLocation(location.id).subscribe({
       next: () => {
         this.saving.set(null);
+        this.clearDraftAndCollapse(location.id);
         this.toastService.success('Ubicación desactivada');
         this.locationService.refreshLocations();
       },
@@ -169,6 +170,7 @@ export class LocationManagerComponent implements OnInit {
     this.locationService.deleteLocation(location.id, true).subscribe({
       next: () => {
         this.saving.set(null);
+        this.clearDraftAndCollapse(location.id);
         this.toastService.success('Ubicación eliminada permanentemente');
         this.locationService.refreshLocations();
       },
@@ -256,6 +258,12 @@ export class LocationManagerComponent implements OnInit {
     if (locationId === 'new') { this.newLocation = this.emptyLocation(); return; }
     const original = (this.locationsSignal() ?? []).find((l) => l.id === locationId);
     if (original) this.drafts[locationId] = this.toDraft(original);
+  }
+
+  private clearDraftAndCollapse(locationId: number): void {
+    delete this.drafts[locationId];
+    if (this.expandedLocationId() === locationId) this.expandedLocationId.set(null);
+    if (this.expandedInactiveId() === locationId) this.expandedInactiveId.set(null);
   }
 
   private toDraft(location: Location): LocationDraft {

--- a/frontend/src/pages/settings/components/product-manager/product-manager.spec.ts
+++ b/frontend/src/pages/settings/components/product-manager/product-manager.spec.ts
@@ -1,0 +1,143 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { Subject } from 'rxjs';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ProductManagerComponent } from './product-manager';
+import { ProductService, type ProductsWithCategories } from '../../../../core/services/product.service';
+import { CategoryService } from '../../../../core/services/category.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
+import type { Product, Category } from '../../../../core/models';
+
+const CAT_A: Category = {
+  id: 10,
+  name: 'Mariscos',
+  description: null,
+  basePrice: null,
+  image: null,
+  displayOrder: 0,
+  active: true,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  _count: { products: 2 },
+};
+
+const PROD_1: Product = {
+  id: 1,
+  categoryId: CAT_A.id,
+  name: 'Camarón al ajillo',
+  description: null,
+  price: 100,
+  image: null,
+  displayOrder: 0,
+  customizable: false,
+  active: true,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  category: { id: CAT_A.id, name: CAT_A.name, basePrice: null },
+};
+
+const PROD_2: Product = { ...PROD_1, id: 2, name: 'Pulpo', displayOrder: 1 };
+
+describe('ProductManagerComponent — issue #51 cleanup', () => {
+  let fixture: ComponentFixture<ProductManagerComponent>;
+  let component: ProductManagerComponent;
+
+  let productsData: ReturnType<typeof signal<ProductsWithCategories | null>>;
+  let categoriesData: ReturnType<typeof signal<Category[] | null>>;
+  let deleteSubject: Subject<void>;
+
+  let productServiceMock: any;
+  let categoryServiceMock: any;
+  let toastServiceMock: { success: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn>; info: ReturnType<typeof vi.fn> };
+  let confirmDialogServiceMock: { confirm: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    productsData = signal<ProductsWithCategories | null>(null);
+    categoriesData = signal<Category[] | null>([CAT_A]);
+    deleteSubject = new Subject();
+
+    productServiceMock = {
+      productsData: productsData.asReadonly(),
+      productsLoading: signal(false).asReadonly(),
+      productsRevalidating: signal(false).asReadonly(),
+      productsError: signal<unknown>(null).asReadonly(),
+      ensureProducts: vi.fn(),
+      refreshProducts: vi.fn(),
+      createProduct: vi.fn().mockReturnValue(new Subject().asObservable()),
+      updateProduct: vi.fn().mockReturnValue(new Subject().asObservable()),
+      deleteProduct: vi.fn().mockReturnValue(deleteSubject.asObservable()),
+      reorderProducts: vi.fn().mockReturnValue(new Subject().asObservable()),
+    };
+
+    categoryServiceMock = { categories: categoriesData.asReadonly() };
+
+    toastServiceMock = { success: vi.fn(), error: vi.fn(), info: vi.fn() };
+    confirmDialogServiceMock = { confirm: vi.fn().mockResolvedValue(true) };
+
+    await TestBed.configureTestingModule({
+      imports: [ProductManagerComponent],
+      providers: [
+        { provide: ProductService, useValue: productServiceMock },
+        { provide: CategoryService, useValue: categoryServiceMock },
+        { provide: ToastService, useValue: toastServiceMock },
+        { provide: ConfirmDialogService, useValue: confirmDialogServiceMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProductManagerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('deactivateProduct() cleanup', () => {
+    beforeEach(() => {
+      productsData.set({ products: [PROD_1, PROD_2], categories: [CAT_A] });
+      TestBed.flushEffects();
+    });
+
+    it('clears expandedProductId and resets draft after success, so opening another row does not trigger the unsaved-changes dialog', async () => {
+      component.expandedProductId.set(PROD_1.id);
+      component.drafts[PROD_1.id].name = 'Edited but not saved';
+
+      await component.deactivateProduct(PROD_1);
+      deleteSubject.next();
+      deleteSubject.complete();
+
+      expect(component.expandedProductId()).toBeNull();
+      expect(component.hasDraftChanges(PROD_1.id)).toBe(false);
+
+      await component.onCollapseToggle(new Event('click'), PROD_2.id);
+
+      expect(confirmDialogServiceMock.confirm).toHaveBeenCalledTimes(1);
+      expect(component.expandedProductId()).toBe(PROD_2.id);
+    });
+
+    it('does NOT clear expanded state on error', async () => {
+      component.expandedProductId.set(PROD_1.id);
+      component.drafts[PROD_1.id].name = 'Edited';
+
+      await component.deactivateProduct(PROD_1);
+      deleteSubject.error(new Error('boom'));
+
+      expect(component.expandedProductId()).toBe(PROD_1.id);
+      expect(component.hasDraftChanges(PROD_1.id)).toBe(true);
+    });
+  });
+
+  describe('permanentDeleteProduct() cleanup', () => {
+    it('clears expandedInactiveProductId after success', async () => {
+      const inactive: Product = { ...PROD_1, id: 5, active: false };
+      productsData.set({ products: [inactive], categories: [CAT_A] });
+      TestBed.flushEffects();
+      component.expandedInactiveProductId.set(inactive.id);
+
+      await component.permanentDeleteProduct(inactive);
+      deleteSubject.next();
+      deleteSubject.complete();
+
+      expect(component.expandedInactiveProductId()).toBeNull();
+      expect(component.drafts[inactive.id]).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/pages/settings/components/product-manager/product-manager.ts
+++ b/frontend/src/pages/settings/components/product-manager/product-manager.ts
@@ -200,6 +200,7 @@ export class ProductManagerComponent implements OnInit {
     this.productService.deleteProduct(product.id).subscribe({
       next: () => {
         this.saving.set(null);
+        this.clearDraftAndCollapse(product.id);
         this.toastService.success('Producto desactivado');
         this.productService.refreshProducts();
       },
@@ -223,6 +224,7 @@ export class ProductManagerComponent implements OnInit {
     this.productService.deleteProduct(product.id, true).subscribe({
       next: () => {
         this.saving.set(null);
+        this.clearDraftAndCollapse(product.id);
         this.toastService.success('Producto eliminado permanentemente');
         this.productService.refreshProducts();
       },
@@ -390,6 +392,12 @@ export class ProductManagerComponent implements OnInit {
   getEffectivePrice(product: Product): number | null {
     const price = product.price ?? product.category.basePrice;
     return this.toNumber(price);
+  }
+
+  private clearDraftAndCollapse(productId: number): void {
+    delete this.drafts[productId];
+    if (this.expandedProductId() === productId) this.expandedProductId.set(null);
+    if (this.expandedInactiveProductId() === productId) this.expandedInactiveProductId.set(null);
   }
 
   private emptyProduct(): CreateProductPayload {

--- a/frontend/src/pages/settings/components/user-manager/user-manager.spec.ts
+++ b/frontend/src/pages/settings/components/user-manager/user-manager.spec.ts
@@ -1,0 +1,121 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { Subject } from 'rxjs';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UserManagerComponent } from './user-manager';
+import { UserService } from '../../../../core/services/user.service';
+import { AuthService } from '../../../../core/services/auth.service';
+import { ToastService } from '../../../../core/services/toast.service';
+import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
+import type { User } from '../../../../core/models';
+
+const USER_1: User = {
+  id: 1,
+  username: 'mesero1',
+  displayName: 'Mesero Uno',
+  role: 'WAITER',
+  active: true,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+const USER_2: User = { ...USER_1, id: 2, username: 'mesero2', displayName: 'Mesero Dos' };
+
+describe('UserManagerComponent — issue #51 cleanup', () => {
+  let fixture: ComponentFixture<UserManagerComponent>;
+  let component: UserManagerComponent;
+
+  let usersData: ReturnType<typeof signal<User[] | null>>;
+  let deleteSubject: Subject<void>;
+  let userServiceMock: any;
+  let authServiceMock: any;
+  let toastServiceMock: { success: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn>; info: ReturnType<typeof vi.fn>; warning: ReturnType<typeof vi.fn> };
+  let confirmDialogServiceMock: { confirm: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    usersData = signal<User[] | null>(null);
+    deleteSubject = new Subject();
+
+    userServiceMock = {
+      users: usersData.asReadonly(),
+      usersLoading: signal(false).asReadonly(),
+      usersRevalidating: signal(false).asReadonly(),
+      usersError: signal<unknown>(null).asReadonly(),
+      ensureUsers: vi.fn(),
+      refreshUsers: vi.fn(),
+      createUser: vi.fn().mockReturnValue(new Subject().asObservable()),
+      updateUser: vi.fn().mockReturnValue(new Subject().asObservable()),
+      deleteUser: vi.fn().mockReturnValue(deleteSubject.asObservable()),
+    };
+
+    authServiceMock = { user: signal<User | null>(null).asReadonly() };
+
+    toastServiceMock = { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() };
+    confirmDialogServiceMock = { confirm: vi.fn().mockResolvedValue(true) };
+
+    await TestBed.configureTestingModule({
+      imports: [UserManagerComponent],
+      providers: [
+        { provide: UserService, useValue: userServiceMock },
+        { provide: AuthService, useValue: authServiceMock },
+        { provide: ToastService, useValue: toastServiceMock },
+        { provide: ConfirmDialogService, useValue: confirmDialogServiceMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UserManagerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('deactivateUser() cleanup', () => {
+    beforeEach(() => {
+      usersData.set([USER_1, USER_2]);
+      TestBed.flushEffects();
+    });
+
+    it('clears expandedUserId and resets draft after success, so opening another row does not trigger the unsaved-changes dialog', async () => {
+      component.expandedUserId.set(USER_1.id);
+      component.drafts[USER_1.id].displayName = 'Edited but not saved';
+
+      await component.deactivateUser(USER_1);
+      deleteSubject.next();
+      deleteSubject.complete();
+
+      expect(component.expandedUserId()).toBeNull();
+      expect(component.hasDraftChanges(USER_1.id)).toBe(false);
+
+      await component.onCollapseToggle(new Event('click'), USER_2.id);
+
+      expect(confirmDialogServiceMock.confirm).toHaveBeenCalledTimes(1);
+      expect(component.expandedUserId()).toBe(USER_2.id);
+    });
+
+    it('does NOT clear expanded state on error', async () => {
+      component.expandedUserId.set(USER_1.id);
+      component.drafts[USER_1.id].displayName = 'Edited';
+
+      await component.deactivateUser(USER_1);
+      deleteSubject.error(new Error('boom'));
+
+      expect(component.expandedUserId()).toBe(USER_1.id);
+      expect(component.hasDraftChanges(USER_1.id)).toBe(true);
+    });
+  });
+
+  describe('permanentDeleteUser() cleanup', () => {
+    it('clears expandedInactiveId after success', async () => {
+      const inactive: User = { ...USER_1, id: 5, active: false };
+      usersData.set([inactive]);
+      TestBed.flushEffects();
+      component.expandedInactiveId.set(inactive.id);
+
+      await component.permanentDeleteUser(inactive);
+      deleteSubject.next();
+      deleteSubject.complete();
+
+      expect(component.expandedInactiveId()).toBeNull();
+      expect(component.drafts[inactive.id]).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/pages/settings/components/user-manager/user-manager.ts
+++ b/frontend/src/pages/settings/components/user-manager/user-manager.ts
@@ -232,6 +232,7 @@ export class UserManagerComponent implements OnInit {
     this.userService.deleteUser(user.id).subscribe({
       next: () => {
         this.saving.set(null);
+        this.clearDraftAndCollapse(user.id);
         this.toastService.success('Usuario desactivado');
         this.userService.refreshUsers();
       },
@@ -269,6 +270,7 @@ export class UserManagerComponent implements OnInit {
     this.userService.deleteUser(user.id, true).subscribe({
       next: () => {
         this.saving.set(null);
+        this.clearDraftAndCollapse(user.id);
         this.toastService.success('Usuario eliminado permanentemente');
         this.userService.refreshUsers();
       },
@@ -294,6 +296,12 @@ export class UserManagerComponent implements OnInit {
 
   resetNewUser(): void {
     this.newUser = this.emptyUser();
+  }
+
+  private clearDraftAndCollapse(userId: number): void {
+    delete this.drafts[userId];
+    if (this.expandedUserId() === userId) this.expandedUserId.set(null);
+    if (this.expandedInactiveId() === userId) this.expandedInactiveId.set(null);
   }
 
   private toDraft(user: User): UserDraft {


### PR DESCRIPTION
## Summary
- Added `clearDraftAndCollapse(id)` helper to all 5 settings managers (categories, products, users, locations, extras) so deactivate and permanent-delete clear the expanded row and discard the in-memory draft, preventing the stale "unsaved changes" confirm dialog (#51).
- Wrapped the Ubicaciones and Extras tab content in `overflow-x-hidden` to match the other tabs' viewport-constrained behavior on mobile (#58).
- Added unit tests for all 5 managers covering deactivate success/error and permanent-delete cleanup.

## Test plan
- [ ] `cd frontend && npm test` — all 5 manager spec files pass
- [ ] Manual QA: open a row in any manager, edit a field, click Deactivate, then expand another row → no "unsaved changes" dialog
- [ ] Manual QA on mobile viewport: Ubicaciones and Extras tabs no longer scroll horizontally
- [ ] Manual QA: same flow with permanent delete on inactive rows

Closes #51
Closes #58