### PR TITLE
Added reusable numeric-input and currency-input directives for price and quantity fields

### DIFF
--- a/.claude/commands/prepare-pr-codex.md
+++ b/.claude/commands/prepare-pr-codex.md
@@ -1,0 +1,158 @@
+Prepare a pull request end-to-end with stricter repo-specific review gates: branch verification, issue context, scoped code review, targeted documentation validation, commit message generation, and guided commit/push/PR creation.
+
+Execute the following phases in order. After each phase, wait for the user's decision before continuing to the next.
+
+**Auto-advance rule (applies to every phase):** if a phase completes and finds nothing that requires user intervention, confirmation, or correction (no ambiguous issue, no branch switch needed, no review findings, no outdated docs, no milestone ambiguity), report the clean result in one line and continue to the next phase automatically. This rule does **not** apply to Phase 3's commit / push / PR steps, which always require explicit confirmation by design.
+
+---
+
+## Phase 0 — Branch Verification, Issue Context, Milestone Context
+
+1. Run `git branch --show-current`, `git status --short`, `git diff --stat HEAD`, and `git diff HEAD` to identify the current branch and working-tree scope.
+2. Identify the issue for the current changes:
+   - First, try to extract an issue number from the branch name (for example `feat/53-order-rounds` → `#53`).
+   - If an issue number is found, run `gh issue view <number>` and verify the issue title/body roughly match the diff. Do not trust branch naming alone.
+   - If no issue is encoded in the branch name, run `gh issue list --state open` and compare issue titles/bodies against the diff.
+   - If there is a confident match, present the inference and wait for the user to confirm.
+   - If there is no confident match, ask the user which issue these changes address or whether there is intentionally no issue.
+3. Resolve the milestone context now, not later:
+   - If an issue was identified and it already has a milestone, use that milestone.
+   - Otherwise, list open milestones with `gh api "repos/{owner}/{repo}/milestones?state=open"` and choose the matching phase milestone by title.
+   - If only one open milestone exists, use it.
+   - If multiple plausible milestones exist, present the options and ask the user to choose.
+   - Cache the resolved milestone title for any issue or PR created later in this command.
+4. If the user confirms there is no existing issue but one should exist:
+   - Propose a concise issue title derived from the diff.
+   - Create it only after confirmation with `gh issue create --assignee @me --milestone "<resolved-milestone-title>"`.
+5. Verify the current branch is correct for the confirmed issue:
+   - If the current branch already encodes the confirmed issue number and its scope matches the diff, the branch is correct.
+   - If the current branch does not match the confirmed issue, determine the base branch:
+     - Default to `master`.
+     - If the current branch has commits ahead of `master` and the new issue is clearly a follow-up or sub-task of that work, ask whether the new branch should be based on the current branch instead.
+   - Generate a branch name following the repo convention: `<type>/<issue-number>-<kebab-title>`.
+   - Present the proposed branch name and base, and ask the user to confirm or edit.
+   - On confirmation, carry the working-tree changes to the new branch:
+     1. Confirm whether the user intentionally has partially staged changes.
+     2. If needed, `git stash push -u -m "prepare-pr-codex carry"`.
+     3. `git checkout <base-branch>`.
+     4. `git pull --ff-only`.
+     5. `git checkout -b <new-branch>`.
+     6. `git stash pop`.
+   - Resolve any stash-pop conflicts before continuing. Never use destructive flags.
+6. Display a summary of:
+   - **Branch:** current branch name
+   - **Issue:** title and number, or `No linked issue`
+   - **Milestone:** resolved milestone title, or `None`
+   - **Checklist:** acceptance criteria or task list from the issue body, if any
+7. This context must be reused in Phase 1 and Phase 3.
+
+**Never commit or push to `master` directly.** If at the end of this phase the branch is still `master`, stop and ask the user before proceeding.
+
+---
+
+## Phase 1 — Code Review, Test Impact, Issue Alignment
+
+1. Run `git diff --stat HEAD`, `git diff HEAD`, and review every changed file intentionally.
+2. Classify each changed file by concern:
+   - frontend UI or routing
+   - frontend API integration
+   - backend API or auth
+   - data model or schema
+   - tests
+   - docs or config
+3. Review the changes with repo-specific gates, not generic style checks only:
+   - **Correctness / regression risk:** logic bugs, broken flows, unsafe assumptions, error handling gaps, auth/security risks, missing edge cases
+   - **Issue alignment:** which acceptance criteria are met, partially met, missing, or contradicted
+   - **Test coverage impact:** whether existing tests cover the change, whether new tests are required, and whether changed behavior can regress silently
+   - **Convention compliance:** rules from `CLAUDE.md` and `.claude/docs/project-instructions.md`
+4. Apply mandatory repo-specific checks:
+   - If frontend behavior or routing changed, check accessibility, UX feedback, and perceived performance implications.
+   - If backend behavior changed, check validation, error handling, authorization, and response-shape stability.
+   - If E2E-covered frontend flows changed and any `/api/*` requests were added or altered, verify the relevant mocks exist in `frontend/e2e/helpers/mocks.ts` or another shared mock helper. Missing stubs must be treated as a review finding, not a suggestion.
+   - If the diff includes unrelated changes outside the linked issue scope, force an explicit decision: keep in this PR, split to another branch, or remove before commit.
+5. Present findings in this structure:
+   - **Correctness / risk** — grouped by severity: High / Medium / Low
+   - **Issue alignment** — `Met`, `Partially met`, `Missing`, `Out of scope`
+   - **Test impact** — `Covered`, `Needs tests`, `Needs mock updates`, `Unclear`
+   - **Convention violations** — only if present
+   - If nothing is found in a section, say so explicitly.
+6. If there are findings:
+   - Separate them into:
+     - **Safe to auto-fix now** — low-risk, unambiguous fixes
+     - **Needs user decision** — scope, behavior, architecture, or product ambiguity
+   - Ask the user:
+     - **Apply safe fixes** — implement the safe fixes and re-run this phase
+     - **Skip fixes** — continue to Phase 2 with findings noted
+     - **Stop** — end the command here
+7. If there are no findings, apply the auto-advance rule and continue to Phase 2.
+
+---
+
+## Phase 2 — Targeted Documentation Check
+
+1. Do not read every doc file by default. Start by mapping changed areas to likely documentation impact:
+   - `README.md` for setup, commands, architecture overview, or developer workflow changes
+   - `CLAUDE.md` and `.claude/docs/project-instructions.md` for repo rules or workflow expectations
+   - `.claude/docs/menu.md` and `.claude/docs/menu.mermaid.md` for menu/data-model changes
+   - `.claude/docs/phases/` specs for feature-scope or phase-progress changes
+2. Read only the documentation files relevant to the diff. Escalate to a broader doc sweep only if the change touches shared architecture, APIs, authentication, data model, or phase-level feature status.
+3. Compare documentation against the actual codebase state and classify results as:
+   - **Must update** — docs would be incorrect or misleading if left unchanged
+   - **Nice to update** — docs could be clearer but are not wrong
+   - **Unaffected** — no update needed
+4. Report:
+   - one line per affected doc file
+   - the exact section that is outdated
+   - what it should say instead at a high level
+5. If any documentation is in **Must update**:
+   - ask the user:
+     - **Apply all required doc updates**
+     - **Pick files**
+     - **Skip docs**
+6. If only **Nice to update** items exist, summarize them and continue unless the user wants them handled.
+7. If all relevant docs are unaffected, apply the auto-advance rule and continue to Phase 3.
+
+---
+
+## Phase 3 — Commit Message, Commit, Push, Pull Request
+
+1. Run `git diff --stat HEAD`, `git diff HEAD`, and `git log --oneline -5`.
+2. Generate a single commit message that:
+   - starts with a past-tense verb
+   - is as short as possible while remaining clear
+   - reflects the actual files intended for commit
+   - matches the tone of recent commit history
+   - never includes `Co-Authored-By` or any AI signature
+3. Reconfirm the milestone before PR creation:
+   - prefer the milestone attached to the linked issue
+   - otherwise use the cached milestone from Phase 0
+   - if neither is available, ask the user whether to proceed without a milestone
+4. Generate a PR title from the commit message and a PR body that includes:
+   - `## Summary` with 1-3 bullets derived from the diff
+   - `## Test plan` with concrete verification steps derived from the changed areas
+   - `## Risks / Notes` only if Phase 1 found known tradeoffs, partial acceptance criteria, or deferred work
+   - `Closes #<issue-number>` if there is a linked issue
+5. Output the proposed commit message and PR body for review.
+6. Ask the user, one step at a time, and wait for confirmation between each:
+   1. **Create the commit?**
+      - Stage only the intended files explicitly.
+      - Do not use `git add -A` or `git add .`.
+      - Run `git commit -m "<message>"`.
+      - Do not amend.
+   2. **Push to `origin`?**
+      - Run `git push -u origin <current-branch>`.
+      - Refuse if the current branch is `master`.
+   3. **Open the pull request?**
+      - Run `gh pr create --base master --head <current-branch> --assignee @me --title "<title>"`.
+      - Add `--milestone "<resolved-milestone-title>"` when a milestone is available.
+      - Add the generated PR body.
+      - Return the PR URL when done.
+7. If the user declines any step, stop there and report the exact current state.
+
+---
+
+## General rule for issues and PRs
+
+Any issue or pull request created by this command, or as a side effect of it, must be created with `--assignee @me`.
+
+If a resolved milestone exists, any issue or pull request created by this command must also use `--milestone "<resolved-milestone-title>"`. Never guess the milestone title when the repository contains multiple plausible options.

--- a/frontend/src/core/models/custom-extra.model.ts
+++ b/frontend/src/core/models/custom-extra.model.ts
@@ -21,5 +21,5 @@ export interface UpdateCustomExtraPayload {
 
 export interface CustomExtraDraft {
   name: string;
-  defaultPrice: string;
+  defaultPrice: number | null;
 }

--- a/frontend/src/pages/bill/bill.html
+++ b/frontend/src/pages/bill/bill.html
@@ -51,8 +51,8 @@
               [value]="qty"
               min="1"
               step="1"
-              (keydown)="preventNonIntegerInput($event)"
-              (paste)="preventDecimalPaste($event)"
+              appNumericInput
+              mode="integer"
               (change)="onQuantityChange(product.id, $event)"
             />
             <button class="join-item btn btn-soft btn-sm btn-success border border-current" (click)="incrementProduct(product.id)">

--- a/frontend/src/pages/bill/bill.ts
+++ b/frontend/src/pages/bill/bill.ts
@@ -5,6 +5,7 @@ import { ConfirmDialogService } from '../../core/services/confirm-dialog.service
 import type { HasUnsavedChanges } from '../../core/guards/unsaved-changes.guard';
 import type { MenuCategory, MenuProduct } from '../../core/models';
 import { IconComponent } from '../../shared/components/icon';
+import { NumericInputDirective } from '../../shared/directives/numeric-input.directive';
 
 interface BillItem {
   productId: number;
@@ -15,7 +16,7 @@ interface BillItem {
 
 @Component({
   selector: 'app-bill-page',
-  imports: [IconComponent],
+  imports: [IconComponent, NumericInputDirective],
   templateUrl: './bill.html',
   styleUrl: './bill.css',
 })
@@ -108,19 +109,6 @@ export class BillPage implements OnInit, HasUnsavedChanges {
     const input = event.target as HTMLInputElement;
     const value = parseInt(input.value, 10);
     this.setQuantity(productId, isNaN(value) ? 0 : value);
-  }
-
-  preventNonIntegerInput(event: KeyboardEvent): void {
-    if (['-', '+', 'e', 'E', '.', ','].includes(event.key)) {
-      event.preventDefault();
-    }
-  }
-
-  preventDecimalPaste(event: ClipboardEvent): void {
-    const text = event.clipboardData?.getData('text') ?? '';
-    if (!/^\d+$/.test(text)) {
-      event.preventDefault();
-    }
   }
 
   hasUnsavedChanges(): boolean {

--- a/frontend/src/pages/settings/components/category-manager/category-manager.html
+++ b/frontend/src/pages/settings/components/category-manager/category-manager.html
@@ -70,7 +70,7 @@
             <label class="input w-full">
               <span class="label w-28 shrink-0">Precio base</span>
               <span>$</span>
-              <input type="number" min="0" step="0.01" placeholder="0.00" [(ngModel)]="drafts[category.id].basePrice" />
+              <input type="text" inputmode="decimal" placeholder="0.00" appCurrencyInput [(ngModel)]="drafts[category.id].basePrice" />
             </label>
 
             <label class="input w-full">
@@ -149,7 +149,7 @@
         <label class="input w-full">
           <span class="label w-28 shrink-0">Precio base</span>
           <span>$</span>
-          <input type="number" min="0" step="0.01" placeholder="0.00" [(ngModel)]="newCategory.basePrice" />
+          <input type="text" inputmode="decimal" placeholder="0.00" appCurrencyInput [(ngModel)]="newCategory.basePrice" />
         </label>
 
         <label class="input w-full">

--- a/frontend/src/pages/settings/components/category-manager/category-manager.ts
+++ b/frontend/src/pages/settings/components/category-manager/category-manager.ts
@@ -12,11 +12,12 @@ import { CategoryService } from '../../../../core/services/category.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
 import { IconComponent } from '../../../../shared/components/icon';
+import { CurrencyInputDirective } from '../../../../shared/directives/currency-input.directive';
 import type { Category, CategoryDraft, CreateCategoryPayload, UpdateCategoryPayload } from '../../../../core/models';
 
 @Component({
   selector: 'app-category-manager',
-  imports: [FormsModule, CdkDropList, CdkDrag, CdkDragHandle, CdkDragPlaceholder, IconComponent],
+  imports: [FormsModule, CdkDropList, CdkDrag, CdkDragHandle, CdkDragPlaceholder, IconComponent, CurrencyInputDirective],
   templateUrl: './category-manager.html',
   styleUrl: '../../../../shared/styles/manager.css',
 })

--- a/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.html
+++ b/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.html
@@ -51,7 +51,7 @@
           <label class="input w-full">
             <span class="label w-28 shrink-0">Precio *</span>
             <span>$</span>
-            <input type="number" min="0" step="0.01" placeholder="0.00" [(ngModel)]="drafts[extra.id].defaultPrice" />
+            <input type="text" inputmode="decimal" placeholder="0.00" appCurrencyInput [(ngModel)]="drafts[extra.id].defaultPrice" />
           </label>
           <div class="divider my-1"></div>
           <div class="flex gap-2">
@@ -111,7 +111,7 @@
         <label class="input w-full">
           <span class="label w-28 shrink-0">Precio *</span>
           <span>$</span>
-          <input type="number" min="0" step="0.01" placeholder="0.00" data-testid="new-extra-price" [(ngModel)]="newExtra.defaultPriceInput" autocomplete="off" />
+          <input type="text" inputmode="decimal" placeholder="0.00" appCurrencyInput data-testid="new-extra-price" [(ngModel)]="newExtra.defaultPrice" autocomplete="off" />
         </label>
         <div class="divider my-1"></div>
         <div class="flex gap-2">
@@ -119,7 +119,7 @@
             class="btn btn-soft btn-success"
             title="Crear"
             data-testid="new-extra-submit"
-            [disabled]="!newExtra.name.trim() || !isValidDraftPrice(newExtra.defaultPriceInput) || saving() === 'new'"
+            [disabled]="!newExtra.name.trim() || !isValidDraftPrice(newExtra.defaultPrice) || saving() === 'new'"
             (click)="createExtra()"
           >
             @if (saving() === 'new') {

--- a/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.spec.ts
+++ b/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.spec.ts
@@ -97,52 +97,27 @@ describe('CustomExtraManagerComponent', () => {
     });
   });
 
-  // ─── parsePrice (via hasDraftChanges) ────────────────────────────────────
-
-  describe('parsePrice() (private — tested through hasDraftChanges)', () => {
-    it('treats empty string as null (differs from stored 8 → changed)', () => {
-      extrasData.set([EXTRA_2]);
-      TestBed.flushEffects();
-      component.drafts[EXTRA_2.id].defaultPrice = '';
-      expect(component.hasDraftChanges(EXTRA_2.id)).toBe(true);
-    });
-
-    it('treats non-numeric input as null (differs from stored 8 → changed)', () => {
-      extrasData.set([EXTRA_2]);
-      TestBed.flushEffects();
-      component.drafts[EXTRA_2.id].defaultPrice = 'abc';
-      expect(component.hasDraftChanges(EXTRA_2.id)).toBe(true);
-    });
-
-    it('treats negative input as null (differs from stored 8 → changed)', () => {
-      extrasData.set([EXTRA_2]);
-      TestBed.flushEffects();
-      component.drafts[EXTRA_2.id].defaultPrice = '-5';
-      expect(component.hasDraftChanges(EXTRA_2.id)).toBe(true);
-    });
-  });
-
   // ─── hasDraftChanges ─────────────────────────────────────────────────────
 
   describe('hasDraftChanges()', () => {
     describe('for "new" extra', () => {
       it('returns false when name and price are empty', () => {
-        component.newExtra = { name: '', defaultPriceInput: '' };
+        component.newExtra = { name: '', defaultPrice: null };
         expect(component.hasDraftChanges('new')).toBe(false);
       });
 
       it('returns true when name is non-empty', () => {
-        component.newExtra = { name: 'Test', defaultPriceInput: '' };
+        component.newExtra = { name: 'Test', defaultPrice: null };
         expect(component.hasDraftChanges('new')).toBe(true);
       });
 
       it('returns true when price input is non-empty even if name is empty', () => {
-        component.newExtra = { name: '', defaultPriceInput: '10' };
+        component.newExtra = { name: '', defaultPrice: 10 };
         expect(component.hasDraftChanges('new')).toBe(true);
       });
 
       it('returns false for whitespace-only name', () => {
-        component.newExtra = { name: '   ', defaultPriceInput: '' };
+        component.newExtra = { name: '   ', defaultPrice: null };
         expect(component.hasDraftChanges('new')).toBe(false);
       });
     });
@@ -163,12 +138,12 @@ describe('CustomExtraManagerComponent', () => {
       });
 
       it('returns true when price has changed', () => {
-        component.drafts[EXTRA_1.id].defaultPrice = '20';
+        component.drafts[EXTRA_1.id].defaultPrice = 20;
         expect(component.hasDraftChanges(EXTRA_1.id)).toBe(true);
       });
 
       it('returns true when price is cleared (15 → null)', () => {
-        component.drafts[EXTRA_1.id].defaultPrice = '';
+        component.drafts[EXTRA_1.id].defaultPrice = null;
         expect(component.hasDraftChanges(EXTRA_1.id)).toBe(true);
       });
 
@@ -182,43 +157,43 @@ describe('CustomExtraManagerComponent', () => {
 
   describe('createExtra()', () => {
     it('is a no-op when name is empty', () => {
-      component.newExtra = { name: '', defaultPriceInput: '' };
+      component.newExtra = { name: '', defaultPrice: null };
       component.createExtra();
       expect(customExtraServiceMock.createExtra).not.toHaveBeenCalled();
     });
 
     it('is a no-op when name is whitespace-only', () => {
-      component.newExtra = { name: '   ', defaultPriceInput: '' };
+      component.newExtra = { name: '   ', defaultPrice: null };
       component.createExtra();
       expect(customExtraServiceMock.createExtra).not.toHaveBeenCalled();
     });
 
-    it('is a no-op when price input is empty', () => {
-      component.newExtra = { name: 'Sal', defaultPriceInput: '' };
+    it('is a no-op when price is null', () => {
+      component.newExtra = { name: 'Sal', defaultPrice: null };
       component.createExtra();
       expect(customExtraServiceMock.createExtra).not.toHaveBeenCalled();
     });
 
-    it('is a no-op when price input is invalid/non-numeric', () => {
-      component.newExtra = { name: 'Sal', defaultPriceInput: 'gratis' };
+    it('is a no-op when price is zero or negative', () => {
+      component.newExtra = { name: 'Sal', defaultPrice: 0 };
       component.createExtra();
       expect(customExtraServiceMock.createExtra).not.toHaveBeenCalled();
     });
 
     it('calls createExtra with trimmed name and defaultPrice', () => {
-      component.newExtra = { name: '  Sal  ', defaultPriceInput: '5.50' };
+      component.newExtra = { name: '  Sal  ', defaultPrice: 5.5 };
       component.createExtra();
       expect(customExtraServiceMock.createExtra).toHaveBeenCalledWith({ name: 'Sal', defaultPrice: 5.5 });
     });
 
     it('sets saving to "new" while the request is in-flight', () => {
-      component.newExtra = { name: 'Sal', defaultPriceInput: '3' };
+      component.newExtra = { name: 'Sal', defaultPrice: 3 };
       component.createExtra();
       expect(component.saving()).toBe('new');
     });
 
     it('resets form, saving, and calls refreshExtras on success', () => {
-      component.newExtra = { name: 'Sal', defaultPriceInput: '3' };
+      component.newExtra = { name: 'Sal', defaultPrice: 3 };
       component.createExtra();
 
       createExtraSubject.next({ ...EXTRA_1, name: 'Sal', defaultPrice: 3 });
@@ -226,13 +201,13 @@ describe('CustomExtraManagerComponent', () => {
 
       expect(component.saving()).toBeNull();
       expect(component.newExtra.name).toBe('');
-      expect(component.newExtra.defaultPriceInput).toBe('');
+      expect(component.newExtra.defaultPrice).toBeNull();
       expect(customExtraServiceMock.refreshExtras).toHaveBeenCalledTimes(1);
       expect(toastServiceMock.success).toHaveBeenCalledWith('Extra creado');
     });
 
     it('resets saving and shows error toast on failure', () => {
-      component.newExtra = { name: 'Sal', defaultPriceInput: '3' };
+      component.newExtra = { name: 'Sal', defaultPrice: 3 };
       component.createExtra();
 
       createExtraSubject.error(new Error('Network error'));
@@ -251,9 +226,9 @@ describe('CustomExtraManagerComponent', () => {
       TestBed.flushEffects();
     });
 
-    it('calls updateExtra with the correct id, name, and parsed price', () => {
+    it('calls updateExtra with the correct id, name, and price', () => {
       component.drafts[EXTRA_1.id].name = 'Aguacate Hass';
-      component.drafts[EXTRA_1.id].defaultPrice = '20';
+      component.drafts[EXTRA_1.id].defaultPrice = 20;
       component.saveExtra(EXTRA_1);
 
       expect(customExtraServiceMock.updateExtra).toHaveBeenCalledWith(EXTRA_1.id, {
@@ -262,21 +237,21 @@ describe('CustomExtraManagerComponent', () => {
       });
     });
 
-    it('is a no-op when price input is empty', () => {
-      component.drafts[EXTRA_1.id].defaultPrice = '';
+    it('is a no-op when price is null', () => {
+      component.drafts[EXTRA_1.id].defaultPrice = null;
       component.saveExtra(EXTRA_1);
 
       expect(customExtraServiceMock.updateExtra).not.toHaveBeenCalled();
     });
 
     it('sets saving to the extra id while in-flight', () => {
-      component.drafts[EXTRA_1.id].defaultPrice = '20';
+      component.drafts[EXTRA_1.id].defaultPrice = 20;
       component.saveExtra(EXTRA_1);
       expect(component.saving()).toBe(EXTRA_1.id);
     });
 
     it('resets saving and calls refreshExtras on success', () => {
-      component.drafts[EXTRA_1.id].defaultPrice = '20';
+      component.drafts[EXTRA_1.id].defaultPrice = 20;
       component.saveExtra(EXTRA_1);
       updateExtraSubject.next(EXTRA_1);
       updateExtraSubject.complete();
@@ -296,7 +271,7 @@ describe('CustomExtraManagerComponent', () => {
 
     it('returns false when "new" is expanded but form is empty', () => {
       component.expandedExtraId.set('new');
-      component.newExtra = { name: '', defaultPriceInput: '' };
+      component.newExtra = { name: '', defaultPrice: null };
       expect(component.hasUnsavedChanges()).toBe(false);
     });
 

--- a/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.ts
+++ b/frontend/src/pages/settings/components/custom-extra-manager/custom-extra-manager.ts
@@ -4,11 +4,12 @@ import { CustomExtraService } from '../../../../core/services/custom-extra.servi
 import { ToastService } from '../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
 import { IconComponent } from '../../../../shared/components/icon';
+import { CurrencyInputDirective } from '../../../../shared/directives/currency-input.directive';
 import type { CustomExtra, CustomExtraDraft, CreateCustomExtraPayload } from '../../../../core/models';
 
 @Component({
   selector: 'app-custom-extra-manager',
-  imports: [FormsModule, IconComponent],
+  imports: [FormsModule, IconComponent, CurrencyInputDirective],
   templateUrl: './custom-extra-manager.html',
   styleUrl: '../../../../shared/styles/manager.css',
 })
@@ -39,7 +40,7 @@ export class CustomExtraManagerComponent implements OnInit {
   );
 
   drafts: Record<number, CustomExtraDraft> = {};
-  newExtra: { name: string; defaultPriceInput: string } = this.emptyExtra();
+  newExtra: { name: string; defaultPrice: number | null } = this.emptyExtra();
 
   constructor() {
     effect(() => {
@@ -69,8 +70,8 @@ export class CustomExtraManagerComponent implements OnInit {
 
   createExtra(): void {
     if (!this.newExtra.name.trim()) return;
-    const price = this.parsePrice(this.newExtra.defaultPriceInput);
-    if (price === null) return;
+    const price = this.newExtra.defaultPrice;
+    if (price === null || price <= 0) return;
     this.saving.set('new');
     const payload: CreateCustomExtraPayload = { name: this.newExtra.name.trim(), defaultPrice: price };
 
@@ -91,8 +92,8 @@ export class CustomExtraManagerComponent implements OnInit {
   saveExtra(extra: CustomExtra): void {
     const draft = this.drafts[extra.id];
     if (!draft) return;
-    const price = this.parsePrice(draft.defaultPrice);
-    if (price === null) return;
+    const price = draft.defaultPrice;
+    if (price === null || price <= 0) return;
     this.saving.set(extra.id);
     this.customExtraService.updateExtra(extra.id, {
       name: draft.name,
@@ -211,18 +212,18 @@ export class CustomExtraManagerComponent implements OnInit {
   }
 
   hasDraftChanges(extraId: number | 'new'): boolean {
-    if (extraId === 'new') return !!this.newExtra.name.trim() || !!this.newExtra.defaultPriceInput.trim();
+    if (extraId === 'new') return !!this.newExtra.name.trim() || this.newExtra.defaultPrice !== null;
     const original = (this.extrasSignal() ?? []).find((e) => e.id === extraId);
     const draft = this.drafts[extraId];
     if (!original || !draft) return false;
     return (
       draft.name !== original.name ||
-      this.parsePrice(draft.defaultPrice) !== this.toNumberOrNull(original.defaultPrice)
+      draft.defaultPrice !== Number(original.defaultPrice)
     );
   }
 
-  isValidDraftPrice(value: string | undefined | null): boolean {
-    return this.parsePrice(value ?? '') !== null;
+  isValidDraftPrice(value: number | null | undefined): boolean {
+    return value != null && value > 0;
   }
 
   resetDraft(extraId: number | 'new'): void {
@@ -241,25 +242,14 @@ export class CustomExtraManagerComponent implements OnInit {
     if (this.expandedInactiveId() === extraId) this.expandedInactiveId.set(null);
   }
 
-  private parsePrice(value: string): number | null {
-    const num = this.toNumberOrNull(value);
-    return num !== null && num > 0 ? num : null;
-  }
-
-  private toNumberOrNull(value: unknown): number | null {
-    if (value == null || value === '') return null;
-    const num = Number(value);
-    return isNaN(num) ? null : num;
-  }
-
   private toDraft(extra: CustomExtra): CustomExtraDraft {
     return {
       name: extra.name,
-      defaultPrice: String(extra.defaultPrice),
+      defaultPrice: Number(extra.defaultPrice),
     };
   }
 
-  private emptyExtra(): { name: string; defaultPriceInput: string } {
-    return { name: '', defaultPriceInput: '' };
+  private emptyExtra(): { name: string; defaultPrice: number | null } {
+    return { name: '', defaultPrice: null };
   }
 }

--- a/frontend/src/pages/settings/components/product-manager/product-manager.html
+++ b/frontend/src/pages/settings/components/product-manager/product-manager.html
@@ -117,9 +117,9 @@
                       <span class="label w-28 shrink-0">Precio</span>
                       <span>$</span>
                       <input
-                        type="number"
-                        step="0.01"
-                        min="0"
+                        type="text"
+                        inputmode="decimal"
+                        appCurrencyInput
                         [(ngModel)]="drafts[product.id].price"
                         placeholder="0.00"
                       />
@@ -229,9 +229,9 @@
             <span class="label w-28 shrink-0">Precio</span>
             <span>$</span>
             <input
-              type="number"
-              step="0.01"
-              min="0"
+              type="text"
+              inputmode="decimal"
+              appCurrencyInput
               [(ngModel)]="newProduct.price"
               placeholder="0.00"
             />

--- a/frontend/src/pages/settings/components/product-manager/product-manager.ts
+++ b/frontend/src/pages/settings/components/product-manager/product-manager.ts
@@ -13,6 +13,7 @@ import { CategoryService } from '../../../../core/services/category.service';
 import { ToastService } from '../../../../core/services/toast.service';
 import { ConfirmDialogService } from '../../../../core/services/confirm-dialog.service';
 import { IconComponent } from '../../../../shared/components/icon';
+import { CurrencyInputDirective } from '../../../../shared/directives/currency-input.directive';
 import type {
   Product,
   CreateProductPayload,
@@ -24,7 +25,7 @@ import type {
 @Component({
   selector: 'app-product-manager',
   standalone: true,
-  imports: [FormsModule, CdkDropList, CdkDrag, CdkDragHandle, CdkDragPlaceholder, IconComponent],
+  imports: [FormsModule, CdkDropList, CdkDrag, CdkDragHandle, CdkDragPlaceholder, IconComponent, CurrencyInputDirective],
   templateUrl: './product-manager.html',
   styleUrl: '../../../../shared/styles/manager.css',
 })

--- a/frontend/src/shared/directives/currency-input.directive.spec.ts
+++ b/frontend/src/shared/directives/currency-input.directive.spec.ts
@@ -1,0 +1,322 @@
+import { Component, viewChild, ElementRef } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { describe, it, expect } from 'vitest';
+import { CurrencyInputDirective } from './currency-input.directive';
+
+@Component({
+  imports: [FormsModule, CurrencyInputDirective],
+  template: `<input #el type="text" appCurrencyInput [(ngModel)]="value" />`,
+})
+class HostComponent {
+  value: number | null = null;
+  inputRef = viewChild.required<ElementRef<HTMLInputElement>>('el');
+}
+
+async function setup(initial: number | null = null) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({ imports: [HostComponent] });
+  const fixture = TestBed.createComponent(HostComponent);
+  fixture.componentInstance.value = initial;
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+  const input = fixture.componentInstance.inputRef().nativeElement;
+  return { fixture, input };
+}
+
+function typeChar(input: HTMLInputElement, ch: string): void {
+  input.value = input.value + ch;
+  input.setSelectionRange(input.value.length, input.value.length);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function typeCharAt(input: HTMLInputElement, ch: string, position: number): void {
+  const value = input.value;
+  input.value = value.slice(0, position) + ch + value.slice(position);
+  input.setSelectionRange(position + 1, position + 1);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function backspaceAt(input: HTMLInputElement, position: number): void {
+  const value = input.value;
+  input.value = value.slice(0, position - 1) + value.slice(position);
+  input.setSelectionRange(position - 1, position - 1);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function pressDeleteOrBackspace(
+  input: HTMLInputElement,
+  key: 'Delete' | 'Backspace',
+  position: number,
+): KeyboardEvent {
+  input.setSelectionRange(position, position);
+  const event = new KeyboardEvent('keydown', { key, cancelable: true, bubbles: true });
+  input.dispatchEvent(event);
+  if (!event.defaultPrevented) {
+    const targetIndex = key === 'Backspace' ? position - 1 : position;
+    if (targetIndex >= 0 && targetIndex < input.value.length) {
+      input.value = input.value.slice(0, targetIndex) + input.value.slice(targetIndex + 1);
+      const newCursor = key === 'Backspace' ? targetIndex : position;
+      input.setSelectionRange(newCursor, newCursor);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  }
+  return event;
+}
+
+function pasteRaw(input: HTMLInputElement, text: string): void {
+  input.value = text;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function backspace(input: HTMLInputElement): void {
+  input.value = input.value.slice(0, -1);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('CurrencyInputDirective', () => {
+  describe('writeValue (model → display)', () => {
+    it('renders empty for null', async () => {
+      const { input } = await setup(null);
+      expect(input.value).toBe('');
+    });
+
+    it('renders 12.34 for value 12.34', async () => {
+      const { input } = await setup(12.34);
+      expect(input.value).toBe('12.34');
+    });
+
+    it('renders empty for 0 (no value entered)', async () => {
+      const { input } = await setup(0);
+      expect(input.value).toBe('');
+    });
+
+    it('renders 0.50 for value 0.5', async () => {
+      const { input } = await setup(0.5);
+      expect(input.value).toBe('0.50');
+    });
+  });
+
+  describe('typing (cents-rolling)', () => {
+    it('rolls digits in from the right: "1" → "0.01"', async () => {
+      const { input } = await setup(null);
+      typeChar(input, '1');
+      expect(input.value).toBe('0.01');
+    });
+
+    it('progresses through 0.01 → 0.12 → 1.23 → 12.34', async () => {
+      const { fixture, input } = await setup(null);
+      typeChar(input, '1');
+      expect(input.value).toBe('0.01');
+      typeChar(input, '2');
+      expect(input.value).toBe('0.12');
+      typeChar(input, '3');
+      expect(input.value).toBe('1.23');
+      typeChar(input, '4');
+      expect(input.value).toBe('12.34');
+      await fixture.whenStable();
+      expect(fixture.componentInstance.value).toBe(12.34);
+    });
+
+    it('places caret at end after typing at end', async () => {
+      const { input } = await setup(null);
+      typeChar(input, '1');
+      typeChar(input, '2');
+      expect(input.selectionStart).toBe(input.value.length);
+      expect(input.selectionEnd).toBe(input.value.length);
+    });
+
+    it('preserves caret position when typing in the middle', async () => {
+      const { input } = await setup(12.34);
+      // value: "12.34", cursor between "1" and "2" → position 1
+      typeCharAt(input, '5', 1);
+      expect(input.value).toBe('152.34');
+      // caret should now sit right after the "5" the user typed → position 2
+      expect(input.selectionStart).toBe(2);
+      expect(input.selectionEnd).toBe(2);
+    });
+
+    it('lets the user type repeatedly at the same logical position', async () => {
+      const { input } = await setup(12.34);
+      typeCharAt(input, '5', 1); // 12.34 → 152.34, caret at 2
+      typeCharAt(input, '6', 2); // 152.34 → 1562.34, caret at 3
+      expect(input.value).toBe('1562.34');
+      expect(input.selectionStart).toBe(3);
+    });
+
+    it('preserves caret position after backspace in the middle', async () => {
+      const { input } = await setup(123.45);
+      // value: "123.45", cursor between "2" and "3" → position 2
+      backspaceAt(input, 2);
+      expect(input.value).toBe('13.45');
+      // there was 1 digit left of cursor → caret at position 1 (after "1")
+      expect(input.selectionStart).toBe(1);
+    });
+
+    it('places caret at end when typing into empty input', async () => {
+      const { input } = await setup(null);
+      typeCharAt(input, '5', 0);
+      expect(input.value).toBe('0.05');
+      expect(input.selectionStart).toBe(input.value.length);
+    });
+
+    it('places caret right after typed digit when typing at the very start of an existing value', async () => {
+      const { input } = await setup(12.34);
+      // value: "12.34", cursor at start (position 0)
+      typeCharAt(input, '5', 0);
+      expect(input.value).toBe('512.34');
+      expect(input.selectionStart).toBe(1);
+    });
+
+    it('caps at MAX_CENTS for absurd inputs', async () => {
+      const { input } = await setup(null);
+      pasteRaw(input, '99999999999');
+      expect(input.value).toBe('999999.99');
+    });
+  });
+
+  describe('paste sanitization', () => {
+    it('extracts digits from messy text and re-formats', async () => {
+      const { input } = await setup(null);
+      pasteRaw(input, 'abc12.50xyz');
+      expect(input.value).toBe('12.50');
+    });
+
+    it('emits null for non-digit-only paste', async () => {
+      const { fixture, input } = await setup(null);
+      pasteRaw(input, 'abcdef');
+      await fixture.whenStable();
+      expect(input.value).toBe('');
+      expect(fixture.componentInstance.value).toBeNull();
+    });
+
+    it('emits 12.5 for paste of "12.50"', async () => {
+      const { fixture, input } = await setup(null);
+      pasteRaw(input, '12.50');
+      await fixture.whenStable();
+      expect(fixture.componentInstance.value).toBe(12.5);
+    });
+  });
+
+  describe('backspace (clearing)', () => {
+    it('rolls digits out: "12.34" → "1.23" → "0.12" → "0.01" → ""', async () => {
+      const { fixture, input } = await setup(12.34);
+      backspace(input);
+      expect(input.value).toBe('1.23');
+      backspace(input);
+      expect(input.value).toBe('0.12');
+      backspace(input);
+      expect(input.value).toBe('0.01');
+      backspace(input);
+      expect(input.value).toBe('');
+      await fixture.whenStable();
+      expect(fixture.componentInstance.value).toBeNull();
+    });
+
+    it('select-all + backspace clears to null', async () => {
+      const { fixture, input } = await setup(45.67);
+      input.value = '';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      await fixture.whenStable();
+      expect(input.value).toBe('');
+      expect(fixture.componentInstance.value).toBeNull();
+    });
+  });
+
+  describe('Delete / Backspace at non-digit positions (ATM-style fallback)', () => {
+    it('Delete on the "." drops the leftmost digit (1.56 → 0.56)', async () => {
+      const { fixture, input } = await setup(1.56);
+      // value: "1.56", cursor between "1" and "." → position 1 (on the ".")
+      const event = pressDeleteOrBackspace(input, 'Delete', 1);
+      expect(event.defaultPrevented).toBe(true);
+      expect(input.value).toBe('0.56');
+      await fixture.whenStable();
+      expect(fixture.componentInstance.value).toBe(0.56);
+    });
+
+    it('Delete from the end keeps shrinking from the left (12.34 → 2.34 → 0.34 → 0.04 → empty)', async () => {
+      const { fixture, input } = await setup(12.34);
+      pressDeleteOrBackspace(input, 'Delete', input.value.length);
+      expect(input.value).toBe('2.34');
+      pressDeleteOrBackspace(input, 'Delete', input.value.length);
+      expect(input.value).toBe('0.34');
+      pressDeleteOrBackspace(input, 'Delete', input.value.length);
+      expect(input.value).toBe('0.04');
+      pressDeleteOrBackspace(input, 'Delete', input.value.length);
+      expect(input.value).toBe('');
+      await fixture.whenStable();
+      expect(fixture.componentInstance.value).toBeNull();
+    });
+
+    it('reproduces the original bug scenario: 1234.56 + Delete×6 from position 1', async () => {
+      const { input } = await setup(1234.56);
+      pressDeleteOrBackspace(input, 'Delete', 1);
+      expect(input.value).toBe('134.56');
+      pressDeleteOrBackspace(input, 'Delete', 1);
+      expect(input.value).toBe('14.56');
+      pressDeleteOrBackspace(input, 'Delete', 1);
+      expect(input.value).toBe('1.56');
+      pressDeleteOrBackspace(input, 'Delete', 1);
+      expect(input.value).toBe('0.56');
+      pressDeleteOrBackspace(input, 'Delete', input.value.length);
+      expect(input.value).toBe('0.06');
+      pressDeleteOrBackspace(input, 'Delete', input.value.length);
+      expect(input.value).toBe('');
+    });
+
+    it('Backspace on the "." drops the rightmost digit (1.56 → 0.15)', async () => {
+      const { fixture, input } = await setup(1.56);
+      // value: "1.56", cursor between "." and "5" → position 2 (Backspace targets ".")
+      const event = pressDeleteOrBackspace(input, 'Backspace', 2);
+      expect(event.defaultPrevented).toBe(true);
+      expect(input.value).toBe('0.15');
+      await fixture.whenStable();
+      expect(fixture.componentInstance.value).toBe(0.15);
+    });
+
+    it('Backspace at the very start shrinks from the right (12.34 → 1.23)', async () => {
+      const { input } = await setup(12.34);
+      pressDeleteOrBackspace(input, 'Backspace', 0);
+      expect(input.value).toBe('1.23');
+    });
+
+    it('Delete on a digit defers to the browser (preserves middle-edit behavior)', async () => {
+      const { input } = await setup(12.34);
+      const event = pressDeleteOrBackspace(input, 'Delete', 1);
+      expect(event.defaultPrevented).toBe(false);
+      expect(input.value).toBe('1.34');
+    });
+
+    it('Backspace on a digit defers to the browser (preserves middle-edit behavior)', async () => {
+      const { input } = await setup(12.34);
+      const event = pressDeleteOrBackspace(input, 'Backspace', 2);
+      expect(event.defaultPrevented).toBe(false);
+      expect(input.value).toBe('1.34');
+    });
+  });
+
+  describe('ngModel integration', () => {
+    it('writes back to the model on every change', async () => {
+      const { fixture, input } = await setup(null);
+      typeChar(input, '5');
+      await fixture.whenStable();
+      expect(fixture.componentInstance.value).toBe(0.05);
+      typeChar(input, '0');
+      await fixture.whenStable();
+      expect(fixture.componentInstance.value).toBe(0.5);
+    });
+
+    it('reflects programmatic writeValue calls on the directive', async () => {
+      const { fixture, input } = await setup(null);
+      const directive = fixture.debugElement
+        .query(By.directive(CurrencyInputDirective))
+        .injector.get(CurrencyInputDirective);
+      directive.writeValue(99.99);
+      expect(input.value).toBe('99.99');
+      directive.writeValue(null);
+      expect(input.value).toBe('');
+    });
+  });
+});

--- a/frontend/src/shared/directives/currency-input.directive.ts
+++ b/frontend/src/shared/directives/currency-input.directive.ts
@@ -1,0 +1,136 @@
+import {
+  Directive,
+  ElementRef,
+  HostListener,
+  forwardRef,
+  inject,
+} from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+const MAX_CENTS = 99_999_999;
+
+@Directive({
+  selector: 'input[appCurrencyInput]',
+  standalone: true,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => CurrencyInputDirective),
+      multi: true,
+    },
+  ],
+})
+export class CurrencyInputDirective implements ControlValueAccessor {
+  private readonly host = inject<ElementRef<HTMLInputElement>>(ElementRef);
+  private onChange: (value: number | null) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  writeValue(value: number | null): void {
+    const cents = this.toCents(value);
+    this.render(cents);
+  }
+
+  registerOnChange(fn: (value: number | null) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.host.nativeElement.disabled = isDisabled;
+  }
+
+  @HostListener('keydown', ['$event'])
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key !== 'Backspace' && event.key !== 'Delete') return;
+    if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return;
+    const input = this.host.nativeElement;
+    const value = input.value;
+    if (!value) return;
+    const start = input.selectionStart ?? value.length;
+    const end = input.selectionEnd ?? start;
+    if (start !== end) return;
+
+    const targetIndex = event.key === 'Backspace' ? start - 1 : start;
+    if (targetIndex >= 0 && targetIndex < value.length && /\d/.test(value[targetIndex])) {
+      return;
+    }
+
+    event.preventDefault();
+    const cents = this.parseCents(value);
+    if (cents === null) return;
+    const next = event.key === 'Backspace'
+      ? Math.floor(cents / 10)
+      : this.dropLeftmostDigit(cents);
+    const newCents = next > 0 ? next : null;
+    this.render(newCents);
+    this.onChange(newCents !== null ? newCents / 100 : null);
+  }
+
+  @HostListener('input')
+  onInput(): void {
+    const input = this.host.nativeElement;
+    const raw = input.value;
+    const cursor = input.selectionStart ?? raw.length;
+    const digitsAfterCursor = raw.slice(cursor).replace(/\D/g, '').length;
+
+    const cents = this.parseCents(raw);
+    this.render(cents, digitsAfterCursor);
+    this.onChange(cents !== null ? cents / 100 : null);
+  }
+
+  @HostListener('blur')
+  onBlur(): void {
+    this.onTouched();
+  }
+
+  private render(cents: number | null, targetDigitsAfter?: number): void {
+    const input = this.host.nativeElement;
+    const display = cents !== null ? (cents / 100).toFixed(2) : '';
+    input.value = display;
+    if (!display) return;
+    const position = this.caretPositionForDigitsAfter(display, targetDigitsAfter);
+    try {
+      input.setSelectionRange(position, position);
+    } catch {
+      /* type=number rejects selection ranges; ignore */
+    }
+  }
+
+  private caretPositionForDigitsAfter(display: string, target?: number): number {
+    if (target === undefined || target <= 0) return display.length;
+    const totalDigits = display.replace(/\D/g, '').length;
+    if (target >= totalDigits) return 0;
+    let counted = 0;
+    for (let i = display.length - 1; i >= 0; i--) {
+      if (/\d/.test(display[i])) {
+        counted++;
+        if (counted === target) {
+          let pos = i;
+          while (pos > 0 && !/\d/.test(display[pos - 1])) pos--;
+          return pos;
+        }
+      }
+    }
+    return display.length;
+  }
+
+  private toCents(value: number | null): number | null {
+    if (value === null || value === undefined) return null;
+    if (!Number.isFinite(value) || value <= 0) return null;
+    return Math.min(Math.round(value * 100), MAX_CENTS);
+  }
+
+  private parseCents(value: string): number | null {
+    const digits = value.replace(/\D/g, '');
+    const parsed = digits ? Number(digits) : 0;
+    return parsed > 0 ? Math.min(parsed, MAX_CENTS) : null;
+  }
+
+  private dropLeftmostDigit(cents: number): number {
+    const digitsStr = String(cents).slice(1);
+    return digitsStr ? Number(digitsStr) : 0;
+  }
+}

--- a/frontend/src/shared/directives/numeric-input.directive.spec.ts
+++ b/frontend/src/shared/directives/numeric-input.directive.spec.ts
@@ -1,0 +1,187 @@
+import { Component, viewChild, ElementRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NumericInputDirective, type NumericInputMode } from './numeric-input.directive';
+
+@Component({
+  imports: [NumericInputDirective],
+  template: `
+    <input
+      #el
+      type="text"
+      [attr.min]="min"
+      appNumericInput
+      [mode]="mode"
+      [maxDecimals]="maxDecimals"
+    />
+  `,
+})
+class HostComponent {
+  mode: NumericInputMode = 'decimal';
+  maxDecimals = 2;
+  min: string | null = null;
+  inputRef = viewChild.required<ElementRef<HTMLInputElement>>('el');
+}
+
+function setup(overrides: Partial<HostComponent> = {}) {
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({ imports: [HostComponent] });
+  const fixture = TestBed.createComponent(HostComponent);
+  Object.assign(fixture.componentInstance, overrides);
+  fixture.detectChanges();
+  const input = fixture.componentInstance.inputRef().nativeElement;
+  return { fixture, input };
+}
+
+function pressKey(input: HTMLInputElement, key: string, init: KeyboardEventInit = {}): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key, cancelable: true, ...init });
+  input.dispatchEvent(event);
+  return event;
+}
+
+function paste(input: HTMLInputElement, text: string): Event {
+  const event = new Event('paste', { cancelable: true, bubbles: true });
+  Object.defineProperty(event, 'clipboardData', {
+    value: { getData: (type: string) => (type === 'text' ? text : '') },
+  });
+  input.dispatchEvent(event);
+  return event;
+}
+
+describe('NumericInputDirective', () => {
+  describe('keydown filtering', () => {
+    it('allows digits in both modes', () => {
+      const { input } = setup({ mode: 'integer' });
+      const event = pressKey(input, '5');
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('blocks letters', () => {
+      const { input } = setup();
+      expect(pressKey(input, 'a').defaultPrevented).toBe(true);
+      expect(pressKey(input, 'Z').defaultPrevented).toBe(true);
+    });
+
+    it('blocks scientific notation and signs', () => {
+      const { input } = setup();
+      for (const key of ['e', 'E', '+', '-']) {
+        expect(pressKey(input, key).defaultPrevented).toBe(true);
+      }
+    });
+
+    it('blocks comma in both modes', () => {
+      const { input } = setup({ mode: 'decimal' });
+      expect(pressKey(input, ',').defaultPrevented).toBe(true);
+    });
+
+    it('blocks period in integer mode', () => {
+      const { input } = setup({ mode: 'integer' });
+      expect(pressKey(input, '.').defaultPrevented).toBe(true);
+    });
+
+    it('allows period in decimal mode when none present', () => {
+      const { input } = setup({ mode: 'decimal' });
+      expect(pressKey(input, '.').defaultPrevented).toBe(false);
+    });
+
+    it('blocks second period in decimal mode', () => {
+      const { input } = setup({ mode: 'decimal' });
+      input.value = '12.';
+      expect(pressKey(input, '.').defaultPrevented).toBe(true);
+    });
+
+    it('blocks digits past maxDecimals at end of value', () => {
+      const { input } = setup({ mode: 'decimal', maxDecimals: 2 });
+      input.value = '1.23';
+      input.setSelectionRange(input.value.length, input.value.length);
+      expect(pressKey(input, '4').defaultPrevented).toBe(true);
+    });
+
+    it('allows navigation and editing keys', () => {
+      const { input } = setup();
+      for (const key of ['Backspace', 'Delete', 'Tab', 'ArrowLeft', 'Home']) {
+        expect(pressKey(input, key).defaultPrevented).toBe(false);
+      }
+    });
+
+    it('does not block keys combined with modifiers (copy/paste shortcuts)', () => {
+      const { input } = setup();
+      const event = new KeyboardEvent('keydown', { key: 'v', ctrlKey: true, cancelable: true });
+      input.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(false);
+    });
+  });
+
+  describe('paste sanitization', () => {
+    let input: HTMLInputElement;
+
+    beforeEach(() => {
+      ({ input } = setup({ mode: 'decimal', maxDecimals: 2 }));
+    });
+
+    it('extracts digits and one period from messy text', () => {
+      const event = paste(input, 'abc12.5xyz');
+      expect(event.defaultPrevented).toBe(true);
+      expect(input.value).toBe('12.5');
+    });
+
+    it('drops empty paste without changing value', () => {
+      input.value = '7';
+      paste(input, 'abc');
+      expect(input.value).toBe('7');
+    });
+
+    it('limits decimals to maxDecimals', () => {
+      paste(input, '3.14159');
+      expect(input.value).toBe('3.14');
+    });
+
+    it('keeps only the first period when multiple are pasted', () => {
+      paste(input, '1.2.3');
+      expect(input.value).toBe('1.23');
+    });
+
+    it('sanitizes integer mode by stripping all non-digits', () => {
+      const setupResult = setup({ mode: 'integer' });
+      paste(setupResult.input, 'a1b2.5c');
+      expect(setupResult.input.value).toBe('125');
+    });
+
+    it('dispatches an input event so ngModel updates', () => {
+      let count = 0;
+      input.addEventListener('input', () => count++);
+      paste(input, '7.5');
+      expect(count).toBe(1);
+    });
+  });
+
+  describe('compositionend (IME)', () => {
+    it('sanitizes value committed by an IME', () => {
+      const { input } = setup({ mode: 'decimal' });
+      input.value = '12abc.5';
+      input.dispatchEvent(new CompositionEvent('compositionend'));
+      expect(input.value).toBe('12.5');
+    });
+
+    it('leaves clean values untouched', () => {
+      const { input } = setup({ mode: 'decimal' });
+      input.value = '12.5';
+      input.dispatchEvent(new CompositionEvent('compositionend'));
+      expect(input.value).toBe('12.5');
+    });
+  });
+
+  describe('min handling', () => {
+    it('clamps pasted value below the host min attribute', () => {
+      const { input } = setup({ mode: 'integer', min: '5' });
+      paste(input, '2');
+      expect(input.value).toBe('5');
+    });
+
+    it('keeps value when above min', () => {
+      const { input } = setup({ mode: 'integer', min: '5' });
+      paste(input, '10');
+      expect(input.value).toBe('10');
+    });
+  });
+});

--- a/frontend/src/shared/directives/numeric-input.directive.ts
+++ b/frontend/src/shared/directives/numeric-input.directive.ts
@@ -1,0 +1,186 @@
+import {
+  Directive,
+  ElementRef,
+  HostListener,
+  Input,
+  inject,
+} from '@angular/core';
+
+export type NumericInputMode = 'integer' | 'decimal';
+
+@Directive({
+  selector: 'input[appNumericInput]',
+  standalone: true,
+})
+export class NumericInputDirective {
+  @Input() mode: NumericInputMode = 'decimal';
+  @Input() maxDecimals = 2;
+
+  private readonly host = inject<ElementRef<HTMLInputElement>>(ElementRef);
+
+  private get min(): number | null {
+    const raw = this.host.nativeElement.min;
+    if (!raw) return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  @HostListener('keydown', ['$event'])
+  onKeydown(event: KeyboardEvent): void {
+    if (event.ctrlKey || event.metaKey || event.altKey) return;
+
+    const navigationKeys = [
+      'Backspace',
+      'Delete',
+      'Tab',
+      'Enter',
+      'Escape',
+      'ArrowLeft',
+      'ArrowRight',
+      'ArrowUp',
+      'ArrowDown',
+      'Home',
+      'End',
+    ];
+    if (navigationKeys.includes(event.key)) return;
+
+    if (['e', 'E', '+', '-'].includes(event.key)) {
+      event.preventDefault();
+      return;
+    }
+
+    if (event.key === ',') {
+      event.preventDefault();
+      return;
+    }
+
+    if (event.key === '.') {
+      if (this.mode !== 'decimal' || this.maxDecimals <= 0) {
+        event.preventDefault();
+        return;
+      }
+      if (this.host.nativeElement.value.includes('.')) {
+        event.preventDefault();
+      }
+      return;
+    }
+
+    if (!/^\d$/.test(event.key)) {
+      event.preventDefault();
+      return;
+    }
+
+    if (this.mode === 'decimal') {
+      const value = this.host.nativeElement.value;
+      const dotIndex = value.indexOf('.');
+      if (dotIndex >= 0) {
+        const decimals = value.length - dotIndex - 1;
+        const cursor = this.cursorPosition();
+        if (cursor === null || cursor > dotIndex) {
+          if (decimals >= this.maxDecimals && !this.hasSelection()) {
+            event.preventDefault();
+          }
+        }
+      }
+    }
+  }
+
+  @HostListener('paste', ['$event'])
+  onPaste(event: ClipboardEvent): void {
+    const raw = event.clipboardData?.getData('text') ?? '';
+    event.preventDefault();
+    this.applySanitizedInsert(raw);
+  }
+
+  @HostListener('drop', ['$event'])
+  onDrop(event: DragEvent): void {
+    const raw = event.dataTransfer?.getData('text') ?? '';
+    event.preventDefault();
+    this.applySanitizedInsert(raw);
+  }
+
+  @HostListener('compositionend')
+  onCompositionEnd(): void {
+    const input = this.host.nativeElement;
+    const sanitized = this.sanitize(input.value);
+    if (input.value !== sanitized) {
+      this.commitValue(sanitized);
+    }
+  }
+
+  private applySanitizedInsert(text: string): void {
+    const input = this.host.nativeElement;
+    const fragment = this.sanitizeFragment(text);
+    if (!fragment) return;
+
+    const supportsSelection = input.type !== 'number';
+    let next: string;
+    if (supportsSelection) {
+      const start = input.selectionStart ?? input.value.length;
+      const end = input.selectionEnd ?? start;
+      next = this.sanitize(
+        input.value.slice(0, start) + fragment + input.value.slice(end)
+      );
+    } else {
+      next = this.sanitize(input.value + fragment);
+    }
+    this.commitValue(next);
+  }
+
+  private commitValue(value: string): void {
+    const input = this.host.nativeElement;
+    input.value = value;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  private sanitize(text: string): string {
+    if (this.mode === 'integer') {
+      const digits = text.replace(/\D/g, '');
+      return this.applyMin(digits);
+    }
+    const cleaned = text.replace(/[^\d.]/g, '');
+    if (this.maxDecimals <= 0) {
+      return this.applyMin(cleaned.replace(/\./g, ''));
+    }
+    const firstDot = cleaned.indexOf('.');
+    if (firstDot < 0) return this.applyMin(cleaned);
+    const intPart = cleaned.slice(0, firstDot);
+    const decPart = cleaned
+      .slice(firstDot + 1)
+      .replace(/\./g, '')
+      .slice(0, this.maxDecimals);
+    return this.applyMin(`${intPart}.${decPart}`);
+  }
+
+  private sanitizeFragment(text: string): string {
+    if (this.mode === 'integer') return text.replace(/\D/g, '');
+    return text.replace(/[^\d.]/g, '');
+  }
+
+  private applyMin(value: string): string {
+    if (value === '' || value === '.') return value;
+    if (this.min === null) return value;
+    const numeric = Number(value);
+    if (Number.isNaN(numeric)) return value;
+    return numeric < this.min ? String(this.min) : value;
+  }
+
+  private cursorPosition(): number | null {
+    try {
+      return this.host.nativeElement.selectionStart;
+    } catch {
+      return null;
+    }
+  }
+
+  private hasSelection(): boolean {
+    const input = this.host.nativeElement;
+    try {
+      const start = input.selectionStart;
+      const end = input.selectionEnd;
+      return start !== null && end !== null && start !== end;
+    } catch {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Added `appNumericInput` directive (integer/decimal modes, paste/drop/IME sanitization, optional `min` and `maxDecimals`) under `frontend/src/shared/directives/` and applied it to the bill calculator quantity input, replacing inline keypress/paste handlers in `BillPage`.
- Added `appCurrencyInput` directive (cents-rolling ATM-style input implementing `ControlValueAccessor`, emitting `number | null`) and applied it to the price/base-price inputs in `category-manager`, `custom-extra-manager`, and `product-manager`. `CustomExtraDraft.defaultPrice` retyped from `string` to `number | null`; `custom-extra-manager` no longer parses strings client-side and its spec is updated accordingly.
- Bundled an unrelated `.claude/commands/prepare-pr-codex.md` slash-command definition.

## Test plan
- [ ] `cd frontend && npm test -- numeric-input.directive currency-input.directive custom-extra-manager` passes
- [ ] In the calculator, typing letters or `+ - e E . ,` in the quantity input is blocked; pasting `abc12xyz` resolves to `12`
- [ ] In Categorías, Extras, and Productos settings tabs, price inputs accept only digits and a single dot, paste of `abc12.5xyz` resolves to `12.50`, and saving stores the numeric value
- [ ] Calculator E2E (`frontend/e2e/calculator.e2e.ts`) and settings E2E (`frontend/e2e/settings.e2e.ts`, including the `new-extra-price` flow) pass without changes

## Risks / Notes
- `category-manager` and `product-manager` still call `toNumberOrNull()`/`isValidDraftPrice()` on values that are already `number | null` after the directive switch. The helpers accept `unknown` so they remain correct, but they are now mildly redundant — left unchanged to keep the diff scoped to #52.
- `.claude/commands/prepare-pr-codex.md` is unrelated to #52 and bundled per maintainer decision rather than split into its own PR.

Closes #52