### PR TITLE
Add orders core schema migration (orders, rounds, items, discounts)

### DIFF
--- a/.claude/docs/issues-dependency-tree.mermaid.md
+++ b/.claude/docs/issues-dependency-tree.mermaid.md
@@ -1,0 +1,49 @@
+# Phase 2 Issues Dependency Tree
+
+> Snapshot as of 2026-07-05. Regenerate from `gh issue list` when issues close or new ones are filed.
+
+```mermaid
+graph TD
+    I46["#46 DB custom_extras (CLOSED)"]
+    I47["#47 DB locations (CLOSED)"]
+    I48["#48 DB orders core schema"]
+    I38["#38 Phase 2 DB migrations (parent)"]
+    I39["#39 Locations management"]
+    I44["#44 Custom extras UI integration"]
+    I40["#40 Open/manage orders + rounds"]
+    I41["#41 Checkout + discounts"]
+    I42["#42 Transfer order / reassign location"]
+    I43["#43 Ticket printing"]
+    I45["#45 Order history + reprint"]
+    I53["#53 Inline extra creation from order view"]
+    I49["#49 UX: surface backend validation errors (no deps)"]
+    I50["#50 UX: unified refresh-button feedback (no deps)"]
+    I16["#16 About page (no deps)"]
+
+    I46 --> I48
+    I47 --> I48
+    I48 --> I38
+    I38 --> I39
+    I38 --> I44
+    I38 --> I40
+    I39 --> I40
+    I40 --> I41
+    I40 --> I42
+    I40 --> I43
+    I41 --> I43
+    I41 --> I45
+    I43 --> I45
+    I40 --> I53
+```
+
+## Suggested resolution order
+
+1. **#48** — DB orders schema (deps #46/#47 already closed, ready now)
+2. **#38** — closes once #48 lands (parent checklist)
+3. **#39** — Locations availability (needs #38)
+4. **#40** — Core order/round flow (needs #38 + #39) — biggest unlock, most other issues wait on this
+5. Parallel after #40: **#41** (checkout), **#42** (transfer), **#44** (extras UI), **#53** (inline extra)
+6. **#43** — Ticket printing (needs #40 + #41)
+7. **#45** — History + reprint (needs #41 + #43) — last in the Phase 2 chain
+
+**Standalone, no dependencies:** #49, #50, #16 — can be done anytime, good filler between phases.

--- a/.claude/docs/phases/Fase 2 - App Marisqueria (Registro de Cuentas).md
+++ b/.claude/docs/phases/Fase 2 - App Marisqueria (Registro de Cuentas).md
@@ -140,16 +140,21 @@ CREATE TABLE orders (
   location_id     INTEGER REFERENCES locations(id),
   bar_position    INTEGER,            -- solo para barra (consecutivo diario auto-asignado)
   takeout_number  INTEGER,            -- solo para para llevar (consecutivo diario)
-  order_type      VARCHAR(20) NOT NULL CHECK (order_type IN ('dine_in', 'bar', 'takeout')),
   status          VARCHAR(20) NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'charged', 'cancelled')),
   owner_user_id   INTEGER NOT NULL REFERENCES users(id),
   opened_at       TIMESTAMP DEFAULT NOW(),
   closed_at       TIMESTAMP,
-  notes           TEXT
+  notes           TEXT,
+  CONSTRAINT orders_service_type_check CHECK (
+    (location_id IS NOT NULL AND takeout_number IS NULL) OR
+    (location_id IS NULL AND takeout_number IS NOT NULL AND bar_position IS NULL)
+  )
 );
 ```
 
 > `bar_position` y `takeout_number` siguen el mismo patrón: el backend calcula el siguiente valor al crear la orden como `MAX(campo) + 1` filtrando por `opened_at >= inicio_del_día_local`, de modo que ambos contadores reinician a las 00:00 sin requerir cron.
+
+> **Nota de diseño:** no existe columna `order_type`. El tipo de servicio se deriva de datos ya presentes: `location_id` + `location.type` distingue mesa vs. barra, y `location_id IS NULL` significa para llevar. Agregar `order_type` sería redundante (viola DRY) y, para el valor `bar`, crearía una inconsistencia cross-table (`order_type='bar'` con una `location.type='table'`) que un CHECK de fila no puede impedir. El `CHECK` de arriba solo fuerza la exclusión mutua entre "tiene ubicación" y "es para llevar"; que `bar_position` corresponda a una ubicación de tipo `bar` se valida en la capa de aplicación (Zod + lógica de servicio), igual que la asignación de los consecutivos diarios.
 
 ### Tabla: `order_rounds`
 

--- a/backend/prisma/migrations/20260705195404_add_orders_core/migration.sql
+++ b/backend/prisma/migrations/20260705195404_add_orders_core/migration.sql
@@ -1,0 +1,101 @@
+-- CreateEnum
+CREATE TYPE "OrderStatus" AS ENUM ('open', 'charged', 'cancelled');
+
+-- CreateEnum
+CREATE TYPE "DiscountType" AS ENUM ('fixed', 'percentage');
+
+-- CreateTable
+CREATE TABLE "orders" (
+    "id" SERIAL NOT NULL,
+    "location_id" INTEGER,
+    "bar_position" INTEGER,
+    "takeout_number" INTEGER,
+    "status" "OrderStatus" NOT NULL DEFAULT 'open',
+    "owner_user_id" INTEGER NOT NULL,
+    "opened_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "closed_at" TIMESTAMP(3),
+    "notes" TEXT,
+
+    CONSTRAINT "orders_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "orders_service_type_check" CHECK (
+        (location_id IS NOT NULL AND takeout_number IS NULL) OR
+        (location_id IS NULL AND takeout_number IS NOT NULL AND bar_position IS NULL)
+    )
+);
+
+-- CreateTable
+CREATE TABLE "order_rounds" (
+    "id" SERIAL NOT NULL,
+    "order_id" INTEGER NOT NULL,
+    "round_number" INTEGER NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "order_rounds_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "order_items" (
+    "id" SERIAL NOT NULL,
+    "round_id" INTEGER NOT NULL,
+    "product_id" INTEGER,
+    "custom_name" VARCHAR(255),
+    "unit_price" DECIMAL(10,2) NOT NULL,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "subtotal" DECIMAL(10,2) GENERATED ALWAYS AS ("unit_price" * "quantity") STORED,
+    "notes" TEXT,
+
+    CONSTRAINT "order_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "order_discounts" (
+    "id" SERIAL NOT NULL,
+    "order_id" INTEGER NOT NULL,
+    "description" VARCHAR(255) NOT NULL,
+    "type" "DiscountType" NOT NULL,
+    "value" DECIMAL(10,2) NOT NULL,
+    "amount" DECIMAL(10,2) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "order_discounts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "orders_status_idx" ON "orders"("status");
+
+-- CreateIndex
+CREATE INDEX "orders_owner_user_id_idx" ON "orders"("owner_user_id");
+
+-- CreateIndex
+CREATE INDEX "orders_opened_at_idx" ON "orders"("opened_at");
+
+-- CreateIndex
+CREATE INDEX "order_rounds_order_id_idx" ON "order_rounds"("order_id");
+
+-- CreateIndex
+CREATE INDEX "order_items_round_id_idx" ON "order_items"("round_id");
+
+-- CreateIndex
+CREATE INDEX "order_discounts_order_id_idx" ON "order_discounts"("order_id");
+
+-- AddForeignKey
+ALTER TABLE "orders" ADD CONSTRAINT "orders_location_id_fkey" FOREIGN KEY ("location_id") REFERENCES "locations"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "orders" ADD CONSTRAINT "orders_owner_user_id_fkey" FOREIGN KEY ("owner_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_rounds" ADD CONSTRAINT "order_rounds_order_id_fkey" FOREIGN KEY ("order_id") REFERENCES "orders"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_rounds" ADD CONSTRAINT "order_rounds_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_items" ADD CONSTRAINT "order_items_round_id_fkey" FOREIGN KEY ("round_id") REFERENCES "order_rounds"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_items" ADD CONSTRAINT "order_items_product_id_fkey" FOREIGN KEY ("product_id") REFERENCES "products"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_discounts" ADD CONSTRAINT "order_discounts_order_id_fkey" FOREIGN KEY ("order_id") REFERENCES "orders"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -29,6 +29,8 @@ model User {
   updatedAt    DateTime @updatedAt @map("updated_at")
 
   customExtras CustomExtra[]
+  orders       Order[]
+  orderRounds  OrderRound[]
 
   @@index([active])
   @@map("users")
@@ -64,6 +66,8 @@ model Location {
   displayOrder Int       @default(0) @map("display_order")
   createdAt    DateTime  @default(now()) @map("created_at")
   updatedAt    DateTime? @updatedAt @map("updated_at")
+
+  orders Order[]
 
   @@index([displayOrder])
   @@index([active])
@@ -108,10 +112,95 @@ model Product {
   updatedAt    DateTime @updatedAt @map("updated_at")
 
   // Relations
-  category Category @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  category   Category    @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  orderItems OrderItem[]
 
   @@index([categoryId])
   @@index([displayOrder])
   @@index([active])
   @@map("products")
+}
+
+// ============================================
+// PHASE 2 — ORDERS
+// ============================================
+
+enum OrderStatus {
+  open
+  charged
+  cancelled
+}
+
+enum DiscountType {
+  fixed
+  percentage
+}
+
+model Order {
+  id             Int         @id @default(autoincrement())
+  locationId     Int?        @map("location_id")
+  barPosition    Int?        @map("bar_position")
+  takeoutNumber  Int?        @map("takeout_number")
+  status         OrderStatus @default(open)
+  ownerUserId    Int         @map("owner_user_id")
+  openedAt       DateTime    @default(now()) @map("opened_at")
+  closedAt       DateTime?   @map("closed_at")
+  notes          String?
+
+  location  Location?       @relation(fields: [locationId], references: [id])
+  owner     User            @relation(fields: [ownerUserId], references: [id])
+  rounds    OrderRound[]
+  discounts OrderDiscount[]
+
+  @@index([status])
+  @@index([ownerUserId])
+  @@index([openedAt])
+  @@map("orders")
+}
+
+model OrderRound {
+  id          Int      @id @default(autoincrement())
+  orderId     Int      @map("order_id")
+  roundNumber Int      @map("round_number")
+  userId      Int      @map("user_id")
+  createdAt   DateTime @default(now()) @map("created_at")
+
+  order Order       @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  user  User        @relation(fields: [userId], references: [id])
+  items OrderItem[]
+
+  @@index([orderId])
+  @@map("order_rounds")
+}
+
+model OrderItem {
+  id         Int     @id @default(autoincrement())
+  roundId    Int     @map("round_id")
+  productId  Int?    @map("product_id")
+  customName String? @db.VarChar(255) @map("custom_name")
+  unitPrice  Decimal @db.Decimal(10, 2) @map("unit_price")
+  quantity   Int     @default(1)
+  subtotal   Decimal @db.Decimal(10, 2)
+  notes      String?
+
+  round   OrderRound @relation(fields: [roundId], references: [id], onDelete: Cascade)
+  product Product?   @relation(fields: [productId], references: [id])
+
+  @@index([roundId])
+  @@map("order_items")
+}
+
+model OrderDiscount {
+  id          Int          @id @default(autoincrement())
+  orderId     Int          @map("order_id")
+  description String       @db.VarChar(255)
+  type        DiscountType
+  value       Decimal      @db.Decimal(10, 2)
+  amount      Decimal      @db.Decimal(10, 2)
+  createdAt   DateTime     @default(now()) @map("created_at")
+
+  order Order @relation(fields: [orderId], references: [id], onDelete: Cascade)
+
+  @@index([orderId])
+  @@map("order_discounts")
 }


### PR DESCRIPTION
## Summary
- Added `Order`, `OrderRound`, `OrderItem`, `OrderDiscount` Prisma models with `OrderStatus`/`DiscountType` enums
- Dropped the redundant `OrderType` enum in favor of deriving service type from `location_id` + `location.type`, enforced via `orders_service_type_check` CHECK constraint
- Hand-edited migration SQL to add `subtotal` as a stored generated column (`unit_price * quantity`) and the service-type CHECK, since Prisma can't express either natively
- Updated the Phase 2 spec doc to match the new design

## Test plan
- [x] `prisma migrate reset --force` runs cleanly on a fresh DB
- [x] Verified cascades: deleting an `Order` removes its `OrderRound`s and `OrderItem`s
- [x] Verified `schema.prisma` matches applied migration SQL field-by-field

Closes #48